### PR TITLE
🌟 new: Adds preflight tests via Nightwatch (second attempt)

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,3 +8,7 @@ dependencies:
     - node_modules
   override:
     - npm install
+
+test:
+  pre:
+    - npm run preflight

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -266,3 +266,33 @@ gulp.task('revreplace', ['revision'], () =>
 //   }))
 //   .pipe(gulp.dest('dist'))
 // );
+
+gulp.task('test:install-selenium', done => {
+  const selenium = require('selenium-standalone');
+  selenium.install({}, done);
+});
+
+gulp.task('test:preflight', ['watch', 'test:install-selenium'], () => {
+  const nightwatch = require('nightwatch');
+
+  if (process.env.CIRCLE_PROJECT_REPONAME === 'starter-kit') {
+    console.info('Project is base starter-kit; bypassing preflight checks...');
+    return process.exit();
+  }
+
+  if (process.env.CIRCLE_BUILD_NUM === 1) {
+    console.info('Initial build; bypassing preflight checks...');
+    return process.exit();
+  }
+
+  return nightwatch.runner({ // eslint-disable-line consistent-return
+    config: 'nightwatch.json',
+    group: 'preflight',
+  }, passed => {
+    if (passed) {
+      process.exit();
+    } else {
+      process.exit(1);
+    }
+  });
+});

--- a/nightwatch.json
+++ b/nightwatch.json
@@ -1,0 +1,57 @@
+{
+  "src_folders" : ["test"],
+  "output_folder" : false,
+  "custom_commands_path" : "",
+  "custom_assertions_path" : "",
+  "page_objects_path" : "",
+  "globals_path" : "",
+
+  "selenium" : {
+    "start_process" : true,
+    "server_path" : "node_modules/selenium-standalone/.selenium/selenium-server/2.53.1-server.jar",
+    "log_path" : "",
+    "host" : "127.0.0.1",
+    "port" : 4444,
+    "cli_args" : {
+      "webdriver.chrome.driver" : "node_modules/selenium-standalone/.selenium/chromedriver/2.22-x64-chromedriver",
+      "webdriver.ie.driver" : ""
+    }
+  },
+
+  "test_settings" : {
+    "default" : {
+      "end_session_on_fail": false,
+      "skip_testcases_on_fail": false,
+      "launch_url" : "http://localhost:3000",
+      "selenium_port"  : 4444,
+      "selenium_host"  : "localhost",
+      "silent": true,
+      "screenshots" : {
+        "enabled" : false,
+        "path" : ""
+      },
+      "desiredCapabilities": {
+        "browserName": "phantomjs",
+        "javascriptEnabled": true,
+        "acceptSslCerts": true,
+        "phantomjs.binary.path" : "node_modules/phantomjs-prebuilt/lib/phantom/bin/phantomjs"
+      }
+    },
+
+    "chrome" : {
+      "desiredCapabilities": {
+        "browserName": "chrome",
+        "javascriptEnabled": true,
+        "acceptSslCerts": true
+      }
+    },
+
+    "firefox" : {
+      "desiredCapabilities": {
+        "browserName": "firefox",
+        "javascriptEnabled": true,
+        "acceptSslCerts": true
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -43,6 +43,11 @@
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.7.0"
   },
+  "optionalDependencies": {
+    "phantomjs-prebuilt": "^2.1.7",
+    "selenium-standalone": "^5.5.0",
+    "nightwatch": "^0.9.5"
+  },
   "engines": {
     "node": ">=6"
   },
@@ -64,6 +69,7 @@
     "prebuild": "npm run clean",
     "prestart": "npm run clean",
     "start": "nodemon --watch gulpfile.babel.js --exec 'gulp watch'",
-    "test": "npm run build"
+    "test": "npm run build",
+    "preflight": "gulp test:preflight"
   }
 }

--- a/test/.eslintrc.yml
+++ b/test/.eslintrc.yml
@@ -1,0 +1,2 @@
+rules:
+  no-unused-expressions: 0

--- a/test/preflight/preflight.spec.js
+++ b/test/preflight/preflight.spec.js
@@ -1,0 +1,211 @@
+module.exports = {
+  /**
+   * Preflight rules
+   * @author Ændrew Rininsland <andrew.rininsland@ft.com>
+   *
+   * These mainly check the existence of various meta data fields and ensures
+   * tracking is installed. It does not verify whether tracking is working or
+   * whether any of the meta values are correct.
+   *
+   * @param  {Nightwatch} client Nightwatch browser object
+   * @return {void}
+   */
+  'load page': client => {
+    client
+      .url('http://localhost:3000')
+      .pause(1000);
+  },
+
+  'HTML title tag should be present': client => {
+    client.expect.element('title').to.be.present;
+    client.getTitle(function assertTitle(title) {
+      this.assert.notEqual(title, ''); // Assert style here because <title> is weird.
+    });
+  },
+
+  'Twitter meta title should be present': client => {
+    client.expect.element('meta[name="twitter:title"]')
+      .to.be.present;
+    client.expect.element('meta[name="twitter:title"]')
+      .to.have.attribute('content').not.equal('');
+  },
+
+  'Open Graph meta title should be present': client => {
+    client.expect.element('meta[property="og:title"]')
+      .to.be.present;
+    client.expect.element('meta[property="og:title"]')
+      .to.have.attribute('content').not.equal('');
+  },
+
+  'HTML meta description should be present': client => {
+    client.expect.element('meta[name="description"]')
+      .to.be.present;
+    client.expect.element('meta[name="description"]')
+      .to.have.attribute('content').not.equal('');
+  },
+
+  'Twitter meta description should be present': client => {
+    client.expect.element('meta[name="twitter:description"]')
+      .to.be.present;
+    client.expect.element('meta[name="twitter:description"]')
+      .to.have.attribute('content').not.equal('');
+  },
+
+  'Open Graph meta description should be present': client => {
+    client.expect.element('meta[property="og:description"]')
+      .to.be.present;
+    client.expect.element('meta[property="og:description"]')
+      .to.have.attribute('content').not.equal('');
+  },
+
+  'Canonical link tag should be present': client => {
+    client.expect.element('link[rel="canonical"]')
+      .to.be.present;
+    client.expect.element('link[rel="canonical"]')
+      .to.have.attribute('href').not.equal('');
+  },
+
+  'Twitter meta url should be present': client => {
+    client.expect.element('meta[name="twitter:url"]')
+      .to.be.present;
+    client.expect.element('meta[name="twitter:url"]')
+      .to.have.attribute('content').not.equal('');
+  },
+
+  'Open Graph meta url should be present': client => {
+    client.expect.element('meta[property="og:url"]')
+      .to.be.present;
+    client.expect.element('meta[property="og:url"]')
+      .to.have.attribute('content').not.equal('');
+  },
+
+  'Image link tag should be present': client => {
+    client.expect.element('link[rel="image_src"]')
+      .to.be.present;
+    client.expect.element('link[rel="image_src"]')
+      .to.have.attribute('href').not.equal('');
+  },
+
+  'Twitter meta image should be present': client => {
+    client.expect.element('meta[name="twitter:image"]')
+      .to.be.present;
+    client.expect.element('meta[name="twitter:image"]')
+      .to.have.attribute('content').not.equal('');
+  },
+
+  'Open Graph meta image should be present': client => {
+    client.expect.element('meta[property="og:image"]')
+      .to.be.present;
+    client.expect.element('meta[property="og:image"]')
+      .to.have.attribute('content').not.equal('');
+  },
+
+  'If optional author info is present, check it is defined': client => {
+    client.element('css selector', 'meta[name="twitter:creator"]', result => {
+      if (result.value && result.value.ELEMENT) {
+        client.expect.element('meta[name="twitter:creator"]')
+          .to.have.attribute('content').not.equal('@individual_account');
+        client.expect.element('meta[name="twitter:creator"]')
+          .to.have.attribute('content').not.equal('');
+
+        client.expect.element('meta[property="article:author"]')
+          .to.have.attribute('content').not.equal('');
+      }
+    });
+  },
+
+  'If optional ft.track:product tag is present, check it is defined': client => {
+    client.element('css selector', 'meta[property="ft.track:product"]', result => {
+      if (result.value && result.value.ELEMENT) {
+        client.expect.element('meta[property="ft.track:product"]')
+          .to.have.attribute('content').not.equal('');
+      }
+    });
+  },
+
+  'If optional ft.track:microsite_name tag is present, check it is defined': client => {
+    client.element('css selector', 'meta[property="ft.track:microsite_name"]', result => {
+      if (result.value && result.value.ELEMENT) {
+        client.expect.element('meta[property="ft.track:microsite_name"]')
+          .to.have.attribute('content').not.equal('');
+      }
+    });
+  },
+
+  'Tracking code should be present': client => {
+    client.expect
+      .element('img[src*="https://spoor-api.ft.com/px.gif"]')
+      .to.be.present.before(1000);
+  },
+
+  'Sharing should be present': client => {
+    client.expect.element('.o-share').to.be.present;
+  },
+
+  'Sharing "links" attribute should be present': client => {
+    client.expect.element('.o-share')
+      .to.have.attribute('data-o-share-links').not.equal('');
+  },
+
+  'Sharing "url" attribute should be present': client => {
+    client.expect.element('.o-share')
+      .to.have.attribute('data-o-share-url').not.equal('');
+  },
+
+  'Sharing "title" attribute should be present': client => {
+    client.expect.element('.o-share')
+      .to.have.attribute('data-o-share-title').not.equal('');
+  },
+
+  'Sharing "summary" attribute should be present': client => {
+    client.expect.element('.o-share')
+      .to.have.attribute('data-o-share-summary').not.equal('');
+  },
+
+  'Topic link should be populated': client => {
+    client.expect.element('.o-typography-link-topic').to.be.present;
+    client.expect.element('.o-typography-link-topic')
+      .to.have.attribute('href').not.equal('');
+
+    client.expect.element('.o-typography-link-topic')
+      .text.to.not.equal('');
+  },
+
+  'Headline should be populated': client => {
+    client.expect.element('h1.o-typography-heading1')
+      .to.be.present;
+    client.expect.element('h1.o-typography-heading1')
+      .text.to.not.equal('');
+  },
+
+  'If optional related article tag is present, check it is defined': client => {
+    client.element('css selector', '.o-typography-lead > .o-typography-link', result => {
+      if (result.value && result.value.ELEMENT) {
+        client.expect.element('.o-typography-lead > .o-typography-link')
+          .to.have.attribute('href').not.equal('');
+        client.expect.element('.o-typography-lead > .o-typography-link')
+          .text.to.not.equal('');
+      }
+    });
+  },
+
+  'If optional timestamp tag is present, check it is defined': client => {
+    client.element('css selector', '.article__timestamp', result => {
+      if (result.value && result.value.ELEMENT) {
+        client.expect.element('.article__timestamp')
+          .text.to.not.equal('');
+      }
+    });
+  },
+
+  'If optional byline tag is present, check it is populated': client => {
+    client.element('css selector', '.article__byline', result => {
+      if (result.value && result.value.ELEMENT) {
+        client.expect.element('.article__byline')
+          .text.to.not.equal('&#32;by&nbsp;');
+      }
+    });
+  },
+
+  '~fin~': client => client.end(),
+};


### PR DESCRIPTION
Because #18 was opened against `ft-interactive#ig-article` instead of `master`, I've opened this new PR so it can merge cleanly.

This adds Nightwatch/Selenium and has about ~50 assertions to check the main meta tags are all filled.