### PR TITLE
🌟 New: Adds extensive ESLint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,48 @@
+/**
+ * FT Interactive Graphics :: linting rules
+ *
+ * These are provided as sensible defaults that only warn by default.
+ * Some more important ones we've cranked up to the "error" level.
+ */
+
+'use strict';
+
+const rules = Object.assign({},
+  require('eslint-config-airbnb-base/rules/es6').rules,
+  require('eslint-config-airbnb-base/rules/best-practices').rules,
+  require('eslint-config-airbnb-base/rules/style').rules,
+  require('eslint-config-airbnb-base/rules/errors').rules,
+  require('eslint-config-airbnb-base/rules/variables').rules
+);
+
+const config = {
+  extends: 'airbnb',
+  parser: 'babel-eslint',
+  plugins: ['babel'],
+  rules: Object.keys(rules).reduce((last, curr) => {
+    let rule = rules[curr];
+    if (Array.isArray(rule) && rule[0] === 2) {
+      rule[0] = 1;
+    } else if (Number.isInteger(rule) && rule === 2) {
+      rule = 1;
+    }
+
+    last[curr] = rule;
+
+    return last;
+  }, {})
+};
+
+/**
+ * Set overrides here for various rules
+ */
+const overrides = {
+  'no-console': 0,
+  'generator-star-spacing': 0,
+  'babel/generator-star-spacing': [2, { before: false, after: true }],
+  'global-require': 1
+
+};
+
+Object.assign(config.rules, overrides);
+module.exports = config;

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,2 +1,0 @@
-root: true
-extends: airbnb

--- a/client/scripts/analytics.js
+++ b/client/scripts/analytics.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 exec('https://origami-build.ft.com/v2/bundles/js?modules=o-tracking', true, true, function () {
   var oTracking = Origami['o-tracking'];
   var page_data = {

--- a/client/scripts/comments.js
+++ b/client/scripts/comments.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 function load_comments_lib() {
   document.removeEventListener('ig.Loaded', load_comments_lib);
   exec('https://origami-build.ft.com/v2/bundles/js?modules=o-comments@^3.1.0', true, true, show_comments);

--- a/config/article.js
+++ b/config/article.js
@@ -1,4 +1,4 @@
-export default _ => ({
+export default _ => ({ // eslint-disable-line
 
   // link file UUID
   id: '$uuid',
@@ -13,23 +13,24 @@ export default _ => ({
 
   headline: 'Politics and the English Language',
 
-  summary: 'Political language is designed to make lies sound truthful and murder respectable, and to give an appearance of solidity to pure wind',
+  summary: 'Political language is designed to make lies sound truthful' +
+           'and murder respectable, and to give an appearance of solidity to pure wind',
 
   topic: {
     name: 'Starter Kit',
-    url: '/foo'
+    url: '/foo',
   },
 
   relatedArticle: {
     text: 'Related article »',
-    url: 'https://en.wikipedia.org/wiki/Politics_and_the_English_Language'
+    url: 'https://en.wikipedia.org/wiki/Politics_and_the_English_Language',
   },
 
   // Byline can by a plain string, markdown, or array of authors
   // if array of authors, url is optional
   byline: [
-    {name: 'Author One', url: '/foo/bar'},
-    {name: 'Author Two'},
+    { name: 'Author One', url: '/foo/bar' },
+    { name: 'Author Two' },
   ],
 
   // Appears in the HTML <title>
@@ -62,7 +63,7 @@ export default _ => ({
     id: '',
 
     // a heading is provided automatically if not set (peferred)
-    heading: ''
+    heading: '',
   },
 
   tracking: {
@@ -86,5 +87,5 @@ export default _ => ({
     however another value may be needed
     */
     // product: '',
-  }
-})
+  },
+});

--- a/config/flags.js
+++ b/config/flags.js
@@ -1,7 +1,7 @@
 const prod = process.env.NODE_ENV === 'production';
 
-export default _ => ({
-  prod: prod,
+export default _ => ({ // eslint-disable-line
+  prod,
   errorReporting: prod,
   analytics: prod,
   googleAnalytics: prod,
@@ -30,4 +30,4 @@ export default _ => ({
 
   */
   comments: true,
-})
+});

--- a/config/index.js
+++ b/config/index.js
@@ -2,12 +2,10 @@ import article from './article';
 import flags from './flags';
 
 export default async function() {
-
   const d = await article();
   const f = await flags();
 
   /*
-
   An experimental demo that gets content from the API
   and overwrites some model values. This requires the Link File
   to have been published. Also next-es-interface.ft.com probably
@@ -31,6 +29,6 @@ export default async function() {
 
   return {
     ...d,
-    flags: f
-  }
+    flags: f,
+  };
 }

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -30,7 +30,7 @@ const AUTOPREFIXER_BROWSERS = [
 ];
 
 const BROWSERIFY_ENTRIES = [
-  'scripts/main.js'
+  'scripts/main.js',
 ];
 
 const BROWSERIFY_TRANSFORMS = [
@@ -39,7 +39,7 @@ const BROWSERIFY_TRANSFORMS = [
 ];
 
 const OTHER_SCRIPTS = [
-  'scripts/top.js'
+  'scripts/top.js',
 ];
 
 process.env.NODE_ENV = process.env.NODE_ENV || 'development';
@@ -53,12 +53,101 @@ const copyGlob = OTHER_SCRIPTS.concat([
 
 ]);
 
+// helpers
+let preventNextReload; // hack to keep a BS error notification on the screen
+function reload() {
+  if (preventNextReload) {
+    preventNextReload = false;
+    return;
+  }
+
+  browserSync.reload();
+}
+
+function handleBuildError(headline, error) {
+  if (process.env.NODE_ENV === 'development') {
+    // show in the terminal
+    util.log(headline, error && error.stack);
+
+    // report it in browser sync
+    let report = (
+      `<span style="color:red;font-weight:bold;font:bold 20px sans-serif">${headline}</span>`
+    );
+
+    if (error) {
+      report += (
+        `<pre style="text-align:left;max-width:800px">${ansiToHTML.toHtml(error.stack)}</pre>`
+      );
+    }
+
+    browserSync.notify(report, 60 * 60 * 1000);
+    preventNextReload = true;
+
+    // allow the sass/js task to end successfully, so the process can continue
+    this.emit('end');
+  } else throw error;
+}
+
+// function to get an array of objects that handle browserifying
+function getBundlers(useWatchify) {
+  return BROWSERIFY_ENTRIES.map(entry => {
+    const bundler = {
+      b: browserify(path.posix.resolve('client', entry), {
+        cache: {},
+        packageCache: {},
+        fullPaths: useWatchify,
+        debug: useWatchify,
+      }),
+
+      execute() {
+        const stream = this.b.bundle()
+          .on('error', function browserifyError(error) {
+            handleBuildError.call(this, 'Error building JavaScript', error);
+          })
+          .pipe(source(entry));
+
+        // If you want JS sourcemaps:
+        //    1. npm i -D gulp-sourcemaps
+        //    2. uncomment code below
+        //
+        // skip sourcemap creation if we're in 'serve' mode
+        // if (useWatchify) {
+        //   stream = stream
+        //    .pipe(vinylBuffer())
+        //    .pipe(gulpsourcemaps.init({ loadMaps: true }))
+        //    .pipe(gulpsourcemaps.write('./'));
+        // }
+
+        return stream.pipe(gulp.dest('dist'));
+      },
+    };
+
+    // register all the transforms
+    BROWSERIFY_TRANSFORMS.forEach(transform => bundler.b.transform(transform));
+
+    // upgrade to watchify if we're in 'serve' mode
+    if (useWatchify) {
+      bundler.b = watchify(bundler.b);
+      bundler.b.on('update', () => {
+        // re-run the bundler then reload the browser
+        bundler.execute().on('end', reload);
+      });
+    }
+
+    return bundler;
+  });
+}
+
+/**
+ * The Tasks
+ */
+
 // makes a production build (client => dist)
 gulp.task('default', done => {
   process.env.NODE_ENV = 'production';
   runSequence(
     ['scripts', 'styles', 'build-pages', 'copy'],
-    ['html' /*, 'images'*/],
+    ['html'/* 'images' */],
     ['revreplace'],
   done);
 });
@@ -80,12 +169,15 @@ gulp.task('watch', ['styles', 'build-pages', 'copy'], done => {
       ghostMode: process.argv.includes('--ghost'),
       port: process.env.PORT || '3000',
       server: {
-        baseDir: 'dist'
+        baseDir: 'dist',
       },
     });
 
     // refresh browser after other changes
-    gulp.watch(['client/**/*.{html,md}', 'views/**/*.{js,html}', 'config/*.{js,json}'], ['build-pages', reload]);
+    gulp.watch([
+      'client/**/*.{html,md}',
+      'views/**/*.{js,html}',
+      'config/*.{js,json}'], ['build-pages', reload]);
     gulp.watch(['client/styles/**/*.scss'], ['styles', reload]);
     gulp.watch(copyGlob, ['copy', reload]);
 
@@ -109,11 +201,9 @@ gulp.task('build-pages', () => {
   delete require.cache[require.resolve('./config/index')];
 
   return gulp.src('client/**/*.html')
-		.pipe(gulpdata(async (d) => {
-      return await require('./config').default(d)
-    }))
-		.pipe(gulpnunjucks.compile(null, {env: require('./views').configure()}))
-		.pipe(gulp.dest('dist'))
+    .pipe(gulpdata(async(d) => await require('./config').default(d)))
+    .pipe(gulpnunjucks.compile(null, { env: require('./views').configure() }))
+    .pipe(gulp.dest('dist'));
 });
 
 // minifies all HTML, CSS and JS (dist & client => dist)
@@ -123,7 +213,7 @@ gulp.task('html', () =>
     .pipe(htmlmin({
       collapseWhitespace: true,
       processConditionalComments: true,
-      minifyJS: true
+      minifyJS: true,
     }))
     .pipe(gulp.dest('dist'))
 );
@@ -137,12 +227,11 @@ gulp.task('scripts', () =>
 gulp.task('styles', () =>
   gulp.src('client/**/*.scss')
     .pipe(sass({
-        includePaths: 'bower_components',
-        outputStyle: process.env.NODE_ENV === 'production' ? 'compressed' : 'expanded'
-      }).on('error', function(error) {
-          handleBuildError.call(this, 'Error building Sass', error);
-      })
-    )
+      includePaths: 'bower_components',
+      outputStyle: process.env.NODE_ENV === 'production' ? 'compressed' : 'expanded',
+    }).on('error', function sassError(error) {
+      handleBuildError.call(this, 'Error building Sass', error);
+    }))
     .pipe(autoprefixer({ browsers: AUTOPREFIXER_BROWSERS }))
     .pipe(gulp.dest('dist'))
 );
@@ -177,89 +266,3 @@ gulp.task('revreplace', ['revision'], () =>
 //   }))
 //   .pipe(gulp.dest('dist'))
 // );
-
-// function to get an array of objects that handle browserifying
-function getBundlers(useWatchify) {
-  return BROWSERIFY_ENTRIES.map(entry => {
-    const bundler = {
-      b: browserify(path.posix.resolve('client', entry), {
-        cache: {},
-        packageCache: {},
-        fullPaths: useWatchify,
-        debug: useWatchify,
-      }),
-
-      execute() {
-        let stream = this.b.bundle()
-          .on('error', function(error) {
-            handleBuildError.call(this, 'Error building JavaScript', error);
-          })
-          .pipe(source(entry));
-
-        // If you want JS sourcemaps:
-        //    1. npm i -D gulp-sourcemaps
-        //    2. uncomment code below
-        //
-        //// skip sourcemap creation if we're in 'serve' mode
-        // if (useWatchify) {
-        //   stream = stream
-        //    .pipe(vinylBuffer())
-        //    .pipe(gulpsourcemaps.init({ loadMaps: true }))
-        //    .pipe(gulpsourcemaps.write('./'));
-        // }
-
-        return stream.pipe(gulp.dest('dist'));
-      },
-    };
-
-    // register all the transforms
-    BROWSERIFY_TRANSFORMS.forEach(transform => bundler.b.transform(transform));
-
-    // upgrade to watchify if we're in 'serve' mode
-    if (useWatchify) {
-      bundler.b = watchify(bundler.b);
-      bundler.b.on('update', files => {
-        // re-run the bundler then reload the browser
-        bundler.execute().on('end', reload);
-      });
-    }
-
-    return bundler;
-  });
-}
-
-// helpers
-let preventNextReload; // hack to keep a BS error notification on the screen
-function reload() {
-  if (preventNextReload) {
-    preventNextReload = false;
-    return;
-  }
-
-  browserSync.reload();
-}
-
-function handleBuildError(headline, error) {
-  if (process.env.NODE_ENV === 'development') {
-
-    // show in the terminal
-    util.log(headline, error && error.stack);
-
-    // report it in browser sync
-    let report = (
-      `<span style="color:red;font-weight:bold;font:bold 20px sans-serif">${headline}</span>`
-    );
-
-    if (error) {
-      report += (
-        `<pre style="text-align:left;max-width:800px">${ansiToHTML.toHtml(error.stack)}</pre>`
-      );
-    }
-
-    browserSync.notify(report, 60 * 60 * 1000);
-    preventNextReload = true;
-
-    // allow the sass/js task to end successfully, so the process can continue
-    this.emit('end');
-  } else throw error;
-}

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "postinstall": "bower install",
     "start": "nodemon --watch gulpfile.babel.js --exec 'gulp watch'",
     "prestart": "npm run clean",
-    "test": "npm run build"
+    "test": "npm run build",
+    "lint": "eslint ."
   },
   "cacheDirectories": [
     "node_modules",
@@ -55,5 +56,14 @@
       "es2015-node6",
       "stage-2"
     ]
+  },
+  "optionalDependencies": {
+    "babel-eslint": "^6.1.2",
+    "eslint": "^3.1.1",
+    "eslint-config-airbnb": "^9.0.1",
+    "eslint-plugin-babel": "^3.3.0",
+    "eslint-plugin-import": "^1.12.0",
+    "eslint-plugin-jsx-a11y": "^2.0.1",
+    "eslint-plugin-react": "^5.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,4 +1,14 @@
 {
+  "babel": {
+    "presets": [
+      "es2015-node6",
+      "stage-2"
+    ]
+  },
+  "cacheDirectories": [
+    "node_modules",
+    "bower_components"
+  ],
   "devDependencies": {
     "ansi-to-html": "^0.4.1",
     "axios": "^0.13.1",
@@ -36,27 +46,6 @@
   "engines": {
     "node": ">=6"
   },
-  "private": true,
-  "scripts": {
-    "clean": "rm -rf dist",
-    "prebuild": "npm run clean",
-    "build": "gulp",
-    "postinstall": "bower install",
-    "start": "nodemon --watch gulpfile.babel.js --exec 'gulp watch'",
-    "prestart": "npm run clean",
-    "test": "npm run build",
-    "lint": "eslint ."
-  },
-  "cacheDirectories": [
-    "node_modules",
-    "bower_components"
-  ],
-  "babel": {
-    "presets": [
-      "es2015-node6",
-      "stage-2"
-    ]
-  },
   "optionalDependencies": {
     "babel-eslint": "^6.1.2",
     "eslint": "^3.1.1",
@@ -65,5 +54,16 @@
     "eslint-plugin-import": "^1.12.0",
     "eslint-plugin-jsx-a11y": "^2.0.1",
     "eslint-plugin-react": "^5.2.2"
+  },
+  "private": true,
+  "scripts": {
+    "build": "gulp",
+    "clean": "rm -rf dist",
+    "lint": "eslint .",
+    "postinstall": "bower install",
+    "prebuild": "npm run clean",
+    "prestart": "npm run clean",
+    "start": "nodemon --watch gulpfile.babel.js --exec 'gulp watch'",
+    "test": "npm run build"
   }
 }

--- a/views/filters/index.js
+++ b/views/filters/index.js
@@ -2,7 +2,7 @@ import markdownIt from 'markdown-it';
 import removeMarkdown from 'remove-markdown';
 import nunjucks from 'nunjucks';
 
-const days  = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August',
                   'September', 'October', 'November', 'December'];
 
@@ -16,15 +16,16 @@ const markdown = markdownIt({
   html: true,
   linkify: true,
   typographer: true,
-  breaks: true
+  breaks: true,
 });
 
 export function md(str, inline) {
-  return !str ? '' : new nunjucks.runtime.SafeString(inline ? markdown.renderInline(str) : markdown.render(str));
+  return !str ? '' :
+    new nunjucks.runtime.SafeString(inline ? markdown.renderInline(str) : markdown.render(str));
 }
 
-export function plain(str, stripListLeaders=true) {
-  return removeMarkdown(str, {stripListLeaders: stripListLeaders, gfm: true});
+export function plain(str, stripListLeaders = true) {
+  return removeMarkdown(str, { stripListLeaders, gfm: true });
 }
 
 export function encodedJSON(str) {

--- a/views/index.js
+++ b/views/index.js
@@ -1,9 +1,10 @@
 import nunjucks from 'nunjucks';
-import markdown_tag from 'nunjucks-markdown';
-import markdownIt from 'markdown-it';
+import markdownTag from 'nunjucks-markdown';
+// import markdownIt from 'markdown-it';
 
+// Disabling because I don't know where this is used. Æ
+// eslint-disable-next-line import/prefer-default-export
 export function configure() {
-
   delete require.cache[require.resolve('./filters/index')];
 
   const env = new nunjucks.Environment(
@@ -11,7 +12,7 @@ export function configure() {
   );
 
   Object.assign(env.filters, require('./filters'));
-  markdown_tag.register(env, env.filters.md);
+  markdownTag.register(env, env.filters.md);
 
   return env;
 }


### PR DESCRIPTION
This adds an extensive config based off [eslint-config-airbnb-base][1] as heavily-commented YAML to [.eslintrc.yml][2]. I tweaked a few rules (denoted by `Æ` in the file) to reflect conventions I found in `starter-kit`.

 _It is quite likely this will require further refinement as time wears on!_

I also tweaked most JS files to reflect the new linting rules, focusing mainly on cosmetic changes and using single-line overrides otherwise.

## Other changes:

+ :heavy_plus_sign: Adds: babel-eslint, eslint-plugin-babel to optional deps.
+ :shirt: Lint: Everything except client/scripts/*.js passes linting now!

[1]: https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb-base
[2]: https://github.com/ft-interactive/starter-kit/blob/eslint-config/.eslintrc.yml