### PR TITLE
🌟 New: Adds basic server boilerplate that supports watching

### DIFF
--- a/.tern-project
+++ b/.tern-project
@@ -1,0 +1,4 @@
+{
+  "ecmaVersion": 6,
+  "libs": []
+}

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node dist/server

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -188,6 +188,31 @@ gulp.task('watch', ['styles', 'build-pages', 'copy'], done => {
   });
 });
 
+// Same as the above, but doesn't run BrowserSync. Used in `npm run server`
+gulp.task('watch-server', ['styles', 'build-pages', 'copy'], done => {
+  const bundlers = getBundlers(true);
+
+  // execute all the bundlers once, up front
+  const initialBundles = mergeStream(bundlers.map(bundler => bundler.execute()));
+  initialBundles.resume(); // (otherwise never emits 'end')
+
+  initialBundles.on('end', () => {
+    // refresh browser after other changes
+    gulp.watch([
+      'client/**/*.{html,md}',
+      'views/**/*.{js,html}',
+      'config/*.{js,json}'], ['build-pages']);
+    gulp.watch(['client/styles/**/*.scss'], ['styles']);
+    gulp.watch(copyGlob, ['copy']);
+
+    // UNCOMMENT IF USING IMAGEMIN
+    // gulp.watch(['client/images/**/*']);
+
+    done();
+  });
+});
+
+
 // copies over miscellaneous files (client => dist)
 gulp.task('copy', () =>
   gulp.src(copyGlob, { dot: true })

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "bower": "^1.7.9",
     "browser-sync": "^2.11.2",
     "browserify": "^13.0.0",
-    "debowerify": "^1.4.1",
+    "debowerify": "github:eugeneware/debowerify#pull/85/head",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^3.1.0",
     "gulp-data": "^1.2.1",
@@ -33,6 +33,7 @@
     "gulp-rev-replace": "^0.4.3",
     "gulp-sass": "^2.3.2",
     "gulp-util": "^3.0.7",
+    "htmlmin": "0.0.6",
     "markdown-it": "^7.0.0",
     "merge-stream": "^1.0.0",
     "nodemon": "^1.9.2",
@@ -77,5 +78,15 @@
     "babel-node": "babel-node --presets=es2015-node6,stage-2",
     "server": "nodemon --watch server --exec npm run babel-node -- server/index.js",
     "transpile-server": "babel --presets=es2015-node6,stage-2 --minified --out-dir dist server/index.js"
+  },
+  "dependencies": {
+    "es6-promisify": "^4.1.0",
+    "glob": "^7.0.5",
+    "koa-manifest-rev": "^0.1.0",
+    "koa-mount": "^2.0.0",
+    "koa-router": "^7.0.1",
+    "koa-static": "^3.0.0",
+    "rev-file": "^2.0.0",
+    "sander": "^0.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,33 +43,39 @@
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.7.0"
   },
-  "optionalDependencies": {
-    "phantomjs-prebuilt": "^2.1.7",
-    "selenium-standalone": "^5.5.0",
-    "nightwatch": "^0.9.5"
-  },
   "engines": {
     "node": ">=6"
   },
   "optionalDependencies": {
+    "babel-cli": "^6.11.4",
     "babel-eslint": "^6.1.2",
     "eslint": "^3.1.1",
     "eslint-config-airbnb": "^9.0.1",
     "eslint-plugin-babel": "^3.3.0",
     "eslint-plugin-import": "^1.12.0",
     "eslint-plugin-jsx-a11y": "^2.0.1",
-    "eslint-plugin-react": "^5.2.2"
+    "eslint-plugin-react": "^5.2.2",
+    "koa": "^2.0.0-alpha.4",
+    "koa-browser-sync": "github:aendrew/koa-browser-sync#updating-deps",
+    "koa-convert": "^1.2.0",
+    "koa-static": "^2.0.0",
+    "phantomjs-prebuilt": "^2.1.7",
+    "selenium-standalone": "^5.5.0",
+    "nightwatch": "^0.9.5"
   },
   "private": true,
   "scripts": {
     "build": "gulp",
     "clean": "rm -rf dist",
     "lint": "eslint .",
-    "postinstall": "bower install",
+    "postinstall": "bower install && npm run build && npm run transpile-server",
     "prebuild": "npm run clean",
     "prestart": "npm run clean",
     "start": "nodemon --watch gulpfile.babel.js --exec 'gulp watch'",
     "test": "npm run build",
-    "preflight": "gulp test:preflight"
+    "preflight": "gulp test:preflight",
+    "babel-node": "babel-node --presets=es2015-node6,stage-2",
+    "server": "nodemon --watch server --exec npm run babel-node -- server/index.js",
+    "transpile-server": "babel --presets=es2015-node6,stage-2 --minified --out-dir dist server/index.js"
   }
 }

--- a/server/.eslintrc.yml
+++ b/server/.eslintrc.yml
@@ -1,0 +1,3 @@
+rules:
+  no-param-reassign: 0
+  global-require: 0

--- a/server/index.js
+++ b/server/index.js
@@ -3,30 +3,37 @@
  *
  * This boilerplate does two things:
  *   - Provides a starting point for Heroku-based server webapps
- *   - (Eventually might) manage all of Starter Kit's build Tasks
+ *   - Manages all of Starter Kit's build Tasks
  */
 
 import Koa from 'koa';
-import convert from 'koa-convert';
-import koaBS from 'koa-browser-sync'; // Optional alternative: https://www.npmjs.com/package/koa-liveload
 import serve from 'koa-static';
-import chalk from 'chalk';
+import mount from 'koa-mount';
+import convert from 'koa-convert';
+import koaBS from 'koa-browser-sync';
+
+import router from './routes';
+import buildInitial from './tasks/build';
+import { errMsg, infoMsg } from './shared';
+
+// Build the initial contents of `dist/`
+try {
+  buildInitial();
+} catch (e) {
+  console.error(errMsg('Error during initial build:'));
+  console.error(e);
+}
 
 const app = new Koa();
 const port = process.env.PORT || 5555;
 
-const msg = chalk.white.bgBlue;
+// Serve out of the contents of `dist/` as static
+app.use(mount('/styles', serve('dist/styles')));
+app.use(mount('/scripts', serve('dist/scripts')));
 
+// Start BrowserSync if NODE_ENV is 'development'.
 if (app.env === 'development') {
-  console.info(msg(' » Starting in development mode '));
-
-  // Run the Gulp watch task without BrowerSync
-  const gulp = require('gulp');
-  require('../gulpfile.babel');
-  if (gulp.tasks.watch) {
-    gulp.start(['watch-server']); // This will be depreciated in Gulp 4
-  }
-
+  console.info(infoMsg(' » Starting in development mode '));
   app.use(convert(koaBS({
     init: true,
     logLevel: 'silent',
@@ -40,8 +47,11 @@ if (app.env === 'development') {
   })));
 }
 
-app.use(convert(serve('dist/')));
+// Populate our routes...
+app.use(router.routes());
+app.use(router.allowedMethods());
 
+// Hey! Listen! ✨
 app.listen(port, () => {
-  console.info(msg(` » Starter Kit server running on port ${port} `));
+  console.info(infoMsg(` » Starter Kit server running on port ${port} `));
 });

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,47 @@
+/**
+ * Starter Kit server app boilerplate
+ *
+ * This boilerplate does two things:
+ *   - Provides a starting point for Heroku-based server webapps
+ *   - (Eventually might) manage all of Starter Kit's build Tasks
+ */
+
+import Koa from 'koa';
+import convert from 'koa-convert';
+import koaBS from 'koa-browser-sync'; // Optional alternative: https://www.npmjs.com/package/koa-liveload
+import serve from 'koa-static';
+import chalk from 'chalk';
+
+const app = new Koa();
+const port = process.env.PORT || 5555;
+
+const msg = chalk.white.bgBlue;
+
+if (app.env === 'development') {
+  console.info(msg(' » Starting in development mode '));
+
+  // Run the Gulp watch task without BrowerSync
+  const gulp = require('gulp');
+  require('../gulpfile.babel');
+  if (gulp.tasks.watch) {
+    gulp.start(['watch-server']); // This will be depreciated in Gulp 4
+  }
+
+  app.use(convert(koaBS({
+    init: true,
+    logLevel: 'silent',
+    files: 'dist/**/*',
+
+    // The following is from the Gulpfile
+    notify: true,
+    open: process.argv.includes('--open'),
+    ui: process.argv.includes('--bsui'),
+    ghostMode: process.argv.includes('--ghost'),
+  })));
+}
+
+app.use(convert(serve('dist/')));
+
+app.listen(port, () => {
+  console.info(msg(` » Starter Kit server running on port ${port} `));
+});

--- a/server/routes.js
+++ b/server/routes.js
@@ -1,0 +1,39 @@
+/**
+ * Server-side routes
+ *
+ * This file is used by the server to set up various application routes.
+ */
+
+import Router from 'koa-router';
+import revManifest from 'koa-manifest-rev';
+import { resolve } from 'path';
+
+import buildHtml from './tasks/templates';
+import devTasks from './tasks/dev';
+import { errMsg } from './shared';
+
+const routes = new Router();
+
+routes.use(devTasks, revManifest({
+  manifest: resolve(__dirname, '../', 'dist/', 'rev-manifest.json'),
+}));
+
+routes.get('/', async (ctx, next) => {
+  await next();
+
+  const filters = [
+    {
+      name: 'rev',
+      func: ctx.state.manifest, // This comes from `koa-manifest-rev`.
+    },
+  ];
+
+  try {
+    ctx.body = await buildHtml(undefined, ...filters); // @TODO pass actual path to buildHtml.
+  } catch (e) {
+    console.error(errMsg('Error building HTML:'));
+    console.error(e);
+  }
+});
+
+export default routes;

--- a/server/shared.js
+++ b/server/shared.js
@@ -1,0 +1,23 @@
+/**
+ * Shared functions
+ */
+
+import promisify from 'es6-promisify';
+import globOriginal from 'glob';
+import { render } from 'node-sass';
+import inlineSource from 'inline-source';
+import chalk from 'chalk';
+
+/**
+ * This promisifies and exports a bunch of the dependencies, thus allowing
+ * them to be used more easily with async/await.
+ */
+export const glob = promisify(globOriginal);
+export const sassRender = promisify(render);
+export const inline = promisify(inlineSource);
+
+/**
+ * This allows shorthand use of Chalk formatting.
+ */
+export const errMsg = chalk.white.bgRed;
+export const infoMsg = chalk.white.bgBlue;

--- a/server/tasks/build.js
+++ b/server/tasks/build.js
@@ -1,0 +1,35 @@
+/**
+ * This is responsible for the initial build
+ */
+
+import glob from 'glob';
+import { resolve, extname } from 'path';
+import { copyFile } from 'sander';
+
+import buildSass from './styles';
+import buildScript from './scripts';
+import buildHtml from './templates';
+import revAssets from './rev';
+
+export default function () {
+  glob(resolve(__dirname, '../../client/**/*'), (err, files) => {
+    files.forEach(file => {
+      switch (extname(file)) {
+        case '.scss':
+          buildSass(file);
+          break;
+        case '.html':
+          buildHtml(file);
+          break;
+        case '.js':
+          buildScript(file);
+          break;
+        default:
+          copyFile(file).to(file.replace('client', 'dist'));
+          break;
+      }
+    });
+
+    revAssets(null, true); // Rev *all* assets (that aren't index.html)
+  });
+}

--- a/server/tasks/dev.js
+++ b/server/tasks/dev.js
@@ -1,0 +1,60 @@
+/**
+ * Development related tasks
+ */
+
+import { extname, resolve } from 'path';
+import { watch } from 'chokidar';
+
+import buildSass from './styles';
+import buildScripts from './scripts';
+import revAssets from './rev';
+import { errMsg } from '../shared';
+
+const distFiles = resolve(__dirname, '../../client/**/*');
+
+// Watch for JS or Sass changes in client/ while in dev mode
+if (process.env.NODE_ENV === 'development') {
+  watch(distFiles).on('all', async (evt, path) => {
+    switch (extname(path)) {
+      case '.scss':
+        try {
+          await buildSass(path);
+        } catch (e) {
+          console.error(errMsg('Error generating styles:'));
+          console.error(e);
+        }
+        break;
+
+      case '.js':
+        try {
+          await buildScripts(path);
+        } catch (e) {
+          console.error(errMsg('Error building bundle:'));
+          console.error(e);
+        }
+        break;
+
+      default:
+        break;
+    }
+
+    revAssets(path); // @TODO add a single asset fork to tasks/rev.js
+  });
+}
+
+
+export default async function devTasks(ctx, next) {
+  await next(); // Wait for the other middleware to finish before continuing...
+
+  // If in development mode, rev all assets on every page load
+  // @TODO Is this excessive? This is probably excessive...
+  // @ACTUALLY, this block can probably be removed once revAssets takes individual paths
+  if (process.env.NODE_ENV === 'development') {
+    try {
+      revAssets(null, true);
+    } catch (e) {
+      console.error(errMsg('Error revving assets:'));
+      console.error(e);
+    }
+  }
+}

--- a/server/tasks/rev.js
+++ b/server/tasks/rev.js
@@ -1,0 +1,62 @@
+/**
+ * Tasks for rev'ing everything
+ *
+ */
+
+import { sync as rev } from 'rev-file';
+import { unlink } from 'fs';
+import { resolve } from 'path';
+import { copyFile, writeFile } from 'sander';
+import { glob, errMsg } from '../shared';
+
+const manifestPath = resolve(__dirname, '../../', 'dist/', 'rev-manifest.json');
+const revRegex = /.+?-[a-z0-9]{10}\.(?:js|css|html)$/;
+const revGlob = 'dist/**/*.{js,css,html,ttf,otf,gif,jpg,jpeg,png}';
+
+export async function clearAllRevved() {
+  const allFiles = await glob(revGlob);
+  allFiles.forEach(filePath => {
+    if (filePath.match(revRegex)) {
+      unlink(filePath, (err) => {
+        if (err) {
+          console.error(errMsg('Error clearing rev cache:'));
+          console.error(err);
+        }
+      });
+    }
+  });
+}
+
+export default async function (path, all = false) {
+  if (all || !path) {
+    clearAllRevved(); // @TODO decide if this should be triggered by something
+
+    try {
+      const allFiles = await glob(revGlob);
+      const manifest = allFiles.reduce((last, curr) => {
+        if (!curr.match(revRegex) && !~curr.indexOf('index.html')) {
+          last[curr.replace('dist/', '')] = rev(curr).replace('dist/', '');
+        }
+
+        return last;
+      }, {});
+
+      Object.keys(manifest).forEach(async key => {
+        try {
+          await copyFile(resolve(__dirname, '../../dist', key))
+            .to(resolve(__dirname, '../../dist', manifest[key]));
+        } catch (e) {
+          console.error(errMsg('Error copying revv\'d asset:'));
+          console.error(e);
+        }
+      });
+
+      writeFile(manifestPath, JSON.stringify(manifest));
+    } catch (e) {
+      console.error(errMsg('Error revving:'));
+      console.error(e);
+    }
+  } else {
+    // @TODO Do something with individual files here? /shrug
+  }
+}

--- a/server/tasks/scripts.js
+++ b/server/tasks/scripts.js
@@ -1,0 +1,37 @@
+/**
+ * JavaScript compilation-related tasks
+ *
+ * @NOTE debowerify currently depends on PR#85. Once merged, revert to parent package.
+ */
+
+import browserify from 'browserify';
+import { resolve, basename } from 'path';
+import { writeFile } from 'sander';
+import promisify from 'es6-promisify';
+
+const BROWSERIFY_TRANSFORMS = [
+  'babelify',
+  'debowerify',
+];
+
+/**
+ * Bundle scripts using Browserify.
+ * @param  {String}  path  Absolute path of entry point
+ * @return {Promise<Buffer>}  Buffer of bundled output.
+ */
+export default async function (path = resolve(__dirname, '../..', 'client/scripts/main.js')) {
+  const b = browserify(path, { cache: {}, packageCache: {} });
+  const bundle = promisify(b.bundle, b);
+  const outPath = resolve(__dirname, `../../dist/scripts/${basename(path)}`);
+
+  BROWSERIFY_TRANSFORMS.forEach(transform => b.transform(transform));
+
+  try {
+    const result = await bundle();
+    await writeFile(outPath, result.toString());
+
+    return result;
+  } catch (e) {
+    return e;
+  }
+}

--- a/server/tasks/styles.js
+++ b/server/tasks/styles.js
@@ -1,0 +1,40 @@
+/**
+ * Sass and styles-related tasks
+ */
+
+import autoprefixer from 'autoprefixer';
+import postcss from 'postcss';
+import { resolve, basename } from 'path';
+import { writeFile } from 'sander';
+
+import { sassRender } from '../shared';
+
+const AUTOPREFIXER_BROWSERS = [
+  'ie >= 8',
+  'ff >= 30',
+  'chrome >= 34',
+  'iOS >= 7',
+  'Safari >= 7',
+];
+const prefixer = postcss([autoprefixer({ browsers: AUTOPREFIXER_BROWSERS })]);
+
+export default async function (path = resolve(__dirname, '../../client/styles/main.scss')) {
+  const outPath = resolve(__dirname, `../../dist/styles/${basename(path, '.scss')}.css`);
+
+  try {
+    // First generate the CSS from Sass...
+    const compiledSass = await sassRender({
+      file: path,
+      outFile: outPath,
+      outputStyle: process.env.NODE_ENV === 'production' ? 'compressed' : 'expanded',
+      includePaths: [resolve(__dirname, '../../bower_components')],
+    });
+
+    // Next run autoprefixer...
+    const processed = await prefixer.process(compiledSass.css.toString());
+
+    return writeFile(undefined, outPath, processed); // sander's writeFile's first arg is basePath
+  } catch (e) {
+    return e;
+  }
+}

--- a/server/tasks/templates.js
+++ b/server/tasks/templates.js
@@ -1,0 +1,51 @@
+/**
+ * Markup rendering-related tasks
+ *
+ * This renders a Nunjucks template, then inlines assets, then minifies the whole shebang.
+ */
+
+
+import promisify from 'es6-promisify';
+import min from 'htmlmin';
+import { resolve, basename } from 'path';
+import { writeFile } from 'sander';
+
+import { configure } from '../../views';
+import { inline } from '../shared';
+import data from '../../config/article'; // I'm not sure if this will work due to `require` caching.
+
+const defaultPath = resolve(__dirname, '../..', 'client/index.html');
+
+/**
+ * Render a template using Nunjucks.
+ * Returns the rendered template to Koa and writes it to `dist/.`
+ *
+ * @param  {String} path  Absolute path of file to render
+ * @return {Promise<string>}  Rendered version of Nunjucks template.
+ */
+export default async function (path = defaultPath, ...filters) {
+  const outPath = resolve(__dirname, `../../dist/${basename(path)}`);
+  const env = configure();
+  const render = promisify(env.render, env);
+
+  filters.forEach(filter => env.addFilter(filter.name, filter.func));
+
+  try {
+    // Render from Nunjucks...
+    const html = await render(path, data());
+
+    // Inline stuff...
+    const inlined = await inline(html, { rootpath: resolve(__dirname, '../../dist') });
+
+    // Compress it...
+    const compressed = min(inlined);
+
+    // Write it to disk...
+    await writeFile(outPath, compressed);
+
+    // Return compressed version to middleware
+    return compressed;
+  } catch (e) {
+    return e;
+  }
+}

--- a/views/includes/html-head.html
+++ b/views/includes/html-head.html
@@ -8,7 +8,7 @@
 <link rel="preconnect" href="https://cdn.polyfill.io">
 
 {# Critical JS and CSS #}
-<script inline src="scripts/top.js"></script>
+<script inline src="{{ 'scripts/top.js' | rev }}"></script>
 <!--[if lt IE 9]><script>/**
 * @preserve HTML5 Shiv 3.7.2 | @afarkas @jdalton @jon_neal @rem | MIT/GPL2 Licensed
 */
@@ -19,7 +19,7 @@
 
 <link rel="stylesheet" href="https://origami-build.ft.com/v2/bundles/css?modules=n-normalize@^1,o-fonts@^2">
 <link rel="stylesheet" href="https://origami-build.ft.com/v2/bundles/css?modules=o-grid@^4,o-typography@^4.2">
-<link rel="stylesheet" href="styles/main.css">
+<link rel="stylesheet" href="{{ 'styles/main.css' | rev }}">
 {% if stylesheets %}{% for stylesheet in stylesheets %}
 <link rel="stylesheet" href="{{ stylesheet }}">
 {% endfor %}{% endif %}

--- a/views/layout.html
+++ b/views/layout.html
@@ -54,7 +54,7 @@
 
     <script async>
     queue([
-      'scripts/main.js'
+      '{{'scripts/main.js' | rev }}'
       {% if scripts %}{% for script in scripts %}
       ,'{{ script }}'
       {% endfor %}{% endif %}


### PR DESCRIPTION
This adds a really basic Koa 2 app that serves out the `dist/` folder on port 5555 upon `$ npm run server`. 

If `NODE_ENV` is set to `development`, it uses BrowserSync to monitor the `dist/` folder, and uses a customised version of the `gulp watch` task (`gulp watch-server`) to monitor the `client/` folder, serving out built versions of `client/` upon change. 

It also adds a `Procfile`, as well as updates `package.json` to build `client/` and transpile `server/` during the npm `postinstall` hook. This enables it to be easily pushed to Heroku. :tada:

Lastly, it consolidates the two `optionalDependency` sections of `package.json` that were added in #19.
