### PR TITLE
🐛 Fixes package.json, adds gulp-plumber.

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -18,6 +18,7 @@ import gulpdata from 'gulp-data';
 import sass from 'gulp-sass';
 import util from 'gulp-util';
 import autoprefixer from 'gulp-autoprefixer';
+import plumber from 'gulp-plumber';
 
 const ansiToHTML = new AnsiToHTML();
 
@@ -201,6 +202,7 @@ gulp.task('build-pages', () => {
   delete require.cache[require.resolve('./config/index')];
 
   return gulp.src('client/**/*.html')
+    .pipe(plumber())
     .pipe(gulpdata(async(d) => await require('./config').default(d)))
     .pipe(gulpnunjucks.compile(null, { env: require('./views').configure() }))
     .pipe(gulp.dest('dist'));
@@ -226,6 +228,7 @@ gulp.task('scripts', () =>
 // builds stylesheets with sass/autoprefixer
 gulp.task('styles', () =>
   gulp.src('client/**/*.scss')
+    .pipe(plumber())
     .pipe(sass({
       includePaths: 'bower_components',
       outputStyle: process.env.NODE_ENV === 'production' ? 'compressed' : 'expanded',

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "gulp-inline-source": "^2.1.0",
     "gulp-minify-html": "^1.0.6",
     "gulp-nunjucks": "^2.2.0",
+    "gulp-plumber": "^1.1.0",
     "gulp-rev": "^7.1.0",
     "gulp-rev-replace": "^0.4.3",
     "gulp-sass": "^2.3.2",
@@ -43,11 +44,6 @@
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.7.0"
   },
-  "optionalDependencies": {
-    "phantomjs-prebuilt": "^2.1.7",
-    "selenium-standalone": "^5.5.0",
-    "nightwatch": "^0.9.5"
-  },
   "engines": {
     "node": ">=6"
   },
@@ -58,7 +54,10 @@
     "eslint-plugin-babel": "^3.3.0",
     "eslint-plugin-import": "^1.12.0",
     "eslint-plugin-jsx-a11y": "^2.0.1",
-    "eslint-plugin-react": "^5.2.2"
+    "eslint-plugin-react": "^5.2.2",
+    "phantomjs-prebuilt": "^2.1.7",
+    "selenium-standalone": "^5.5.0",
+    "nightwatch": "^0.9.5"
   },
   "private": true,
   "scripts": {


### PR DESCRIPTION
Because template files will kill `npm start` without error, this adds `gulp-plumber` to the `build-html` and `styles` tasks, which makes errors much more visible.

It also fixes `package.json`, which had duplicate `optionalDependencies` entries following the merging of #18.