### PR TITLE
🐛 Backports preflight fixes from pensions-interestrates

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,8 +11,10 @@ dependencies:
     - npm install
 
 test:
-  pre:
+  post:
     - npm run preflight
+    - mv -fv dist/* $CIRCLE_ARTIFACTS
+
 
 deployment:
   s3: # this is just a custom name, could be anything

--- a/circle.yml
+++ b/circle.yml
@@ -13,11 +13,13 @@ dependencies:
 test:
   post:
     - npm run preflight
-    - mv -fv dist/* $CIRCLE_ARTIFACTS
-
 
 deployment:
   s3: # this is just a custom name, could be anything
     branch: /.*/
     commands:
       - npm run deploy:confirm
+
+general:
+  artifacts:
+    - dist

--- a/nightwatch.json
+++ b/nightwatch.json
@@ -13,7 +13,7 @@
     "host" : "127.0.0.1",
     "port" : 4444,
     "cli_args" : {
-      "webdriver.chrome.driver" : "node_modules/selenium-standalone/.selenium/chromedriver/2.22-x64-chromedriver",
+      "webdriver.chrome.driver" : "node_modules/selenium-standalone/.selenium/chromedriver/2.23-x64-chromedriver",
       "webdriver.ie.driver" : ""
     }
   },
@@ -34,7 +34,7 @@
         "browserName": "phantomjs",
         "javascriptEnabled": true,
         "acceptSslCerts": true,
-        "phantomjs.binary.path" : "node_modules/phantomjs-prebuilt/lib/phantom/bin/phantomjs"
+        "phantomjs.binary.path" : "node_modules/phantomjs-prebuilt/bin/phantomjs"
       }
     },
 

--- a/package.json
+++ b/package.json
@@ -66,9 +66,9 @@
     "nodegit": "^0.14.1",
     "ora": "^0.3.0",
     "parse-github-url": "^0.3.1",
-    "phantomjs-prebuilt": "^2.1.12",
+    "phantomjs-prebuilt": "2.1.12",
     "s3": "^4.4.0",
-    "selenium-standalone": "^5.5.0"
+    "selenium-standalone": "5.6.1"
   },
   "private": true,
   "scripts": {


### PR DESCRIPTION
PhantomJS path changed, as did a few things with selenium-standalone.

This fixes the versions of selenium-standalone and phantomjs-prebuilt to 5.6.1 and 2.1.12 respectively. It also backports @kavanagh's fixes to preflight from ft-interactive/pensions-interestrates.