### PR TITLE
🐛 Adds Circle config to install libstdc++-4.9-dev

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,6 +9,10 @@ dependencies:
     - node_modules
   override:
     - npm install
+  pre:
+    - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+    - sudo apt-get update
+    - sudo apt-get install -y libstdc++-4.9-dev
 
 test:
   post:


### PR DESCRIPTION
This installs libstdc++-4.9-dev when deploying on CircleCI, which was needed to solve a deployment error due to nodegit in ft-interactive/future-of-the-city.