### PR TITLE
Updates package.json to use fork of inline-source

### DIFF
--- a/client/components/core/top.js
+++ b/client/components/core/top.js
@@ -36,18 +36,24 @@ function exec(script) {
   if (s === 'string') {
     try {
       add_script.apply(window, arguments);
-    } catch(e) {}
+    } catch(e) {
+      console.error(e);
+    }
   } else if (s === 'function') {
     try {
       script();
-    } catch(e) {}
+    } catch(e) {
+      console.error(e);
+    }
   } else if (script) {
-    try{
+    try {
       var args = Array.prototype.slice.call(arguments, 1);
       for (var i = 0; i < script.length; i++) {
         exec.apply(window, [script[i]].concat(args));
       }
-    } catch(e){}
+    } catch(e){
+      console.error(e);
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "gulp-rev-replace": "^0.4.3",
     "gulp-sass": "^2.3.2",
     "gulp-util": "^3.0.7",
+    "inline-source": "github:aendrew/inline-source",
     "markdown-it": "^7.0.1",
     "merge-stream": "^1.0.0",
     "nodemon": "^1.10.2",


### PR DESCRIPTION
Fork passes `mangle: {keep_fnames: true}` which prevents `inline-source` from breaking `top.js`. Supercedes #46, fixes #45.