### PR TITLE
Adds get() filter

### DIFF
--- a/views/filters/index.js
+++ b/views/filters/index.js
@@ -98,3 +98,6 @@ export function spoorTrackingPixel(str) {
   <noscript data-o-component="o-tracking">${img}</noscript>`,
   );
 }
+
+// Get an item from an object. Useful when combined with `set` and `first()`.
+export const get = (obj, prop) => obj[prop];


### PR DESCRIPTION
This new filter allows you to do things like:

```
    {% set illustrator = data.options | first | get('illustrations') %}
    <em>Illustrations by {{ illustrator }}</em>
```

Useful in situations where you have a Bertha sheet and define a one-row column for sundry microtext.