### PR TITLE
stop excluding Symbol from polyfill

### DIFF
--- a/client/components/core/top.js
+++ b/client/components/core/top.js
@@ -143,8 +143,7 @@ var polyfill_features = [
 ];
 
 var polfill_url = 'https://cdn.polyfill.io/v2/polyfill.min.js?callback=clear_queue&features='
-                    + polyfill_features.join(',')
-                    + '&excludes=Symbol,Symbol.iterator,Symbol.species';
+                    + polyfill_features.join(',');
 
 exec(polfill_url, true, false, null, {crossorigin: 'anonymous'})
 


### PR DESCRIPTION
Issue which made us first include it (I think?) seems to have been
fixed: https://github.com/Financial-Times/polyfill-service/issues/715