### PR TITLE
Add new share buttons & fix surrounding layout

### DIFF
--- a/client/components/core/_main.scss
+++ b/client/components/core/_main.scss
@@ -9,69 +9,26 @@ body {
   font-family: $font-sans;
 }
 
-$share-button-size: 38px;
-.o-share--muted {
-  .o-share__action {
-    line-height: $share-button-size;
-
-    a {
-      width: $share-button-size;
-      &:hover {
-      }
-    }
-
-    i {
-      width: $share-button-size;
-      height: $share-button-size;
-      text-indent: $share-button-size;
-      border: 1px solid #e9decf;
-      &:hover {
-        opacity: 1;
-        background-color: #e9decf;
-      }
-    }
-
-    &--twitter i {
-      background-image:url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9Ii0xMTMgLTEwMyA0MCA0MCI+PHBhdGggZmlsbD0iI2E3YTU5YiIgZD0iTS04MS44NjItODkuNzg2Yy0uODIuMzU3LTEuNy42LTIuNjI0LjcwOC45NDMtLjU1NiAxLjY2OC0xLjQzNiAyLjAxLTIuNDgzLS44ODMuNTEtMS44NjIuODgtMi45MDIgMS4wOC0uODMzLS44Ny0yLjAyLTEuNDItMy4zMzctMS40Mi0yLjUyMyAwLTQuNTcgMi4wMS00LjU3IDQuNDkgMCAuMzUuMDQuNjkuMTE4IDEuMDItMy44LS4xOS03LjE2Ny0xLjk3OC05LjQyLTQuNjktLjM5NC42Ni0uNjIgMS40My0uNjIgMi4yNiAwIDEuNTUuODA3IDIuOTMgMi4wMzMgMy43My0uNzUtLjAyNS0xLjQ1NC0uMjI4LTIuMDctLjU2di4wNTRjMCAyLjE3NiAxLjU3MyAzLjk5IDMuNjY3IDQuNC0uMzg0LjEwNC0uNzkuMTYtMS4yMDQuMTYtLjMgMC0uNTgtLjAyNy0uODYtLjA4LjU4IDEuNzgyIDIuMjcgMy4wOCA0LjI3IDMuMTE2LTEuNTcgMS4yMDUtMy41NCAxLjkyMy01LjY4IDEuOTIzLS4zNyAwLS43NC0uMDI2LTEuMDktLjA2NyAyLjAyIDEuMjcyIDQuNDIgMi4wMTUgNyAyLjAxNSA4LjQgMCAxMy02Ljg0IDEzLTEyLjc3IDAtLjE5NC0uMDA3LS4zOS0uMDE4LS41OC44OS0uNjMzIDEuNjY1LTEuNDI1IDIuMjgtMi4zMjV6Ii8+PC9zdmc+)
-    }
-
-    &--facebook i {
-      background-image:url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9Ii0xMTQgLTEwNSA0MCA0MCI+PHBhdGggZmlsbD0iI2E3YTU5YiIgZD0iTS05Ny05MS40NHYyLjk1aC0yLjE3djMuNjJILTk3djEwLjcyaDQuNDN2LTEwLjcyaDNzLjI2LTEuNzMuNC0zLjYyaC0zLjM4di0yLjQ3YzAtLjM3LjUtLjg3Ljk2LS44N2gyLjQzdi0zLjc1aC0zLjI4Yy00LjY2IDAtNC41NSAzLjYzLTQuNTUgNC4xNnoiLz48L3N2Zz4=)
-    }
-  }
-}
-
 .article {
   &-head {
     margin-top: 18px;
-    margin-bottom: 18px;
-    .o-share--vertical {
-      float: right;
-      .o-share__action {
-        margin: 0 0 0 5px;
-        a,
-        a:first-child {
-          padding-top: 0;
-          padding-bottom: 5px;
-        }
-      }
-    }
+    margin-bottom: 0px;
   }
 
   &-body {
-    & > :not(.graphic) {
-      max-width: 625px;
-      margin: 1em auto;
-      padding: 0 0.75em;
+    div[data-o-grid-colspan] {
+      padding: 0;
+      & > div {
+        max-width: 700px;
+      }
     }
   }
 }
 
 .graphic {
-
   display: block;
   max-width: 100%;
-  margin: 0 auto;
+  margin: 0;
   padding: 0;
   box-sizing: border-box;
   width: 100%;
@@ -96,6 +53,6 @@ $share-button-size: 38px;
 .enhanced .o-date {opacity: 0;}
 .enhanced.js-success .o-date {opacity: 1;}
 
-.article-head .o-share--vertical .o-share__action {
-  box-sizing: content-box !important;
-}
+
+
+

--- a/client/index.html
+++ b/client/index.html
@@ -1,25 +1,14 @@
 {% extends "layout.html" %}
 
 {% block article_body %}
+	
 {% markdown %}
 
-...the defense of the English language implies more than this, and perhaps it is best to start by saying what it does _not_ imply.
+To begin with it has nothing to do with archaism, with the salvaging of obsolete words and turns of speech, or with the setting up of a "standard English" which must never be departed from. On the contrary, it isespecially concerned with the scrapping of every word or idiom which has outworn its usefulness. 
 
-<figure class="graphic graphic-b-1 graphic-pad-1">
-  <img alt="" src="https://image.webservices.ft.com/v1/images/raw/http%3A%2F%2Fcom.ft.imagepublish.prod.s3.amazonaws.com%2Fc4bf0be4-7c15-11e4-a7b8-00144feabdc0?source=ig&fit=scale-down&width=700"></img>
-    <figcaption class="o-typography-caption">
-    <a class="o-typography-link" href="#void">&#xA9;Credit person</a> George Orwell at his typewriter
-  </figcaption>
-</figure>
+It has nothing to do with correct grammar and syntax,which are of no importance so long as one makes one's meaning clear, or with the avoidance of Americanisms, or with having what is called a "good prose style." 
 
-To begin with it has nothing to do with archaism, with the salvaging of
-obsolete words and turns of speech, or with the setting up of a "standard
-English" which must never be departed from. On the contrary, it is
-especially concerned with the scrapping of every word or idiom which has
-outworn its usefulness. It has nothing to do with correct grammar and syntax,
-which are of no importance so long as one makes one's meaning clear, or with
-the avoidance of Americanisms, or with having what is called a "good prose
-style." On the other hand, it is not concerned with fake simplicity and
+On the other hand, it is not concerned with fake simplicity and
 the attempt to make written English colloquial. Nor does it even imply in every
 case preferring the Saxon word to the Latin one, though it does imply using the fewest and shortest words that will cover one's meaning. What is above all
 needed is to let the meaning choose the word, and not the other way around. In prose, the worst thing one can do with words is surrender to them. When you think of a concrete object, you think wordlessly, and then, if you want to

--- a/config/article.js
+++ b/config/article.js
@@ -29,8 +29,9 @@ export default () => ({ // eslint-disable-line
 
   mainImage: {
     title: '',
-    description: '',
-    url: '',
+    description: 'George Orwell at his typewriter',
+    credit: 'Credit person',
+    url: 'https://image.webservices.ft.com/v1/images/raw/http%3A%2F%2Fcom.ft.imagepublish.prod.s3.amazonaws.com%2Fc4bf0be4-7c15-11e4-a7b8-00144feabdc0?source=ig&fit=scale-down&width=700',
     width: 2048, // ensure correct width
     height: 1152, // ensure correct height
   },

--- a/views/includes/article-head.html
+++ b/views/includes/article-head.html
@@ -4,13 +4,25 @@
 
 <h1 class="o-typography-heading1" itemprop="headline">{{ headline | md(true) }}</h1>
 
-<p class="o-typography-lead">
+<p>
   {{ summary | md(true) }}
   {% if relatedArticle %}
   <a href="{{ relatedArticle.url }}" class="o-typography-link">{{ relatedArticle.text }}</a>
   {% endif %}
 </p>
 <meta itemprop="dateModified" content="{{ publishedDate | isotime }}">
+
+<figure class="graphic graphic-b-1 graphic-pad-1">
+  <img alt="" src="{{ mainImage.url }}"></img>
+    <figcaption class="o-typography-caption">
+     {{mainImage.description}} 
+     &#xA9;{{mainImage.credit}}
+  </figcaption>
+</figure>
+
+{% if flags.shareButtons %}
+  {% include "includes/share.html" %}
+{% endif %}
 
 <p>
   {%- if publishedDate -%}

--- a/views/includes/share.html
+++ b/views/includes/share.html
@@ -1,10 +1,20 @@
-<link rel="stylesheet" href="https://origami-build.ft.com/v2/bundles/css?modules=o-share@^2">
-<div data-o-component="o-share"
-    class="o-share o-share--vertical o-share--muted"
-    data-o-share-links="twitter facebook"
-    data-o-share-url="{{ url }}"
-    data-o-share-title="{{ socialHeadline | default(headline, true) | plain }}"
-    data-o-share-summary="{{ socialSummary | default(summary, true) | plain }}"
-    data-o-share-relatedTwitterAccounts="@ft">
+<link rel="stylesheet" href="https://origami-build.ft.com/v2/bundles/css?modules=o-share@^3">
+
+<div class="article__share article__share--top n-util-clearfix" data-trackable="share | top">
+	<div class="container">
+		<div data-o-component="o-share" class="o-share">
+			<ul>
+				<li class="o-share__action o-share__action--twitter">
+					<a href="https://twitter.com/intent/tweet?url={{ url }}&amp;related={{ topic.name }}&amp;via=FT" rel="noopener"><i>Twitter</i></a>
+				</li>
+				<li class="o-share__action o-share__action--facebook">
+					<a href="http://www.facebook.com/sharer.php?u={{ url }}" rel="noopener"><i>Facebook</i></a>
+				</li>
+				<li class="o-share__action o-share__action--linkedin">
+					<a href="https://www.linkedin.com/shareArticle?mini=true&amp;url={{ url }}&amp;source=Financial%20Times" rel="noopener"><i>LinkedIn</i></a>
+				</li>
+			</ul>
+		</div>
+	</div>
 </div>
-<script async>queue('https://origami-build.ft.com/v2/bundles/js?export=oShare&modules=o-share@^2', null, true)</script>
+<script async>queue('https://origami-build.ft.com/v2/bundles/js?export=oShare&modules=o-share@^3.2.2', null, true)</script>

--- a/views/layout.html
+++ b/views/layout.html
@@ -25,11 +25,6 @@
             <header data-o-grid-colspan="12 S11 Scenter M9 L8 XL7">
 
               {% block article_head %}
-
-              {% if flags.shareButtons %}
-                {% include "includes/share.html" %}
-              {% endif %}
-
               {% include "includes/article-head.html" %}
               {% endblock %}
 
@@ -38,7 +33,13 @@
         </div>
         <div class="article-body o-typography-body-wrapper" itemprop="articleBody">
 
-          {% block article_body %}{% endblock %}
+          <div class="o-grid-container">
+            <div data-o-grid-colspan="12 S11 Scenter M9 L8 XL7">
+              <div>
+                {% block article_body %}{% endblock %}
+              </div>
+            </div>
+          </div>
 
           <footer class="o-typography-footer" itemprop="publisher" itemscope itemtype="https://schema.org/Organization">
             <small><a href="http://www.ft.com/servicestools/help/copyright" data-trackable="link-copyright">Copyright</a>


### PR DESCRIPTION
Adding  the new [origami share buttons](http://registry.origami.ft.com/components/o-share@3.2.2) as below, to replace the old share buttons.

This meant I also had to hack column width around a bit so that the edge of the text column aligns with the edge of the top graphic. The new share buttons made the indent on the body copy look weird. 

I also removed css relating to the old share buttons. 

From request by @cnev177 

## New share buttons
![screen shot 2017-05-08 at 17 46 59](https://cloud.githubusercontent.com/assets/10324129/25814730/65d0abae-3416-11e7-9b1f-83a3c86f4a76.png)

## Old share buttons 
![screen shot 2017-05-08 at 10 53 29](https://cloud.githubusercontent.com/assets/10324129/25813372/2f47953e-3411-11e7-917f-449eec9c89fc.png)

## New column alignment 
![screen shot 2017-05-08 at 17 34 20](https://cloud.githubusercontent.com/assets/10324129/25814240/a5f7c598-3414-11e7-9139-7bb3cf7b3984.png)



## Old column alignment 
![screen shot 2017-05-08 at 17 15 28](https://cloud.githubusercontent.com/assets/10324129/25813560/f8944fa4-3411-11e7-9b63-35178f10a8fc.png)

