### PR TITLE
Fix footer

### DIFF
--- a/client/components/core/_main.scss
+++ b/client/components/core/_main.scss
@@ -12,12 +12,11 @@ body {
 .article {
   &-head {
     margin-top: 18px;
-    margin-bottom: 0px;
+    margin-bottom: 0;
   }
 
   &-body {
     div[data-o-grid-colspan] {
-      padding: 0;
       & > div {
         max-width: 700px;
       }

--- a/config/article.js
+++ b/config/article.js
@@ -29,8 +29,8 @@ export default () => ({ // eslint-disable-line
 
   mainImage: {
     title: '',
-    description: 'George Orwell at his typewriter',
-    credit: 'Credit person',
+    description: '',
+    credit: '',
     url: 'https://image.webservices.ft.com/v1/images/raw/http%3A%2F%2Fcom.ft.imagepublish.prod.s3.amazonaws.com%2Fc4bf0be4-7c15-11e4-a7b8-00144feabdc0?source=ig&fit=scale-down&width=700',
     width: 2048, // ensure correct width
     height: 1152, // ensure correct height

--- a/views/layout.html
+++ b/views/layout.html
@@ -34,17 +34,26 @@
         <div class="article-body o-typography-body-wrapper" itemprop="articleBody">
 
           <div class="o-grid-container">
-            <div data-o-grid-colspan="12 S11 Scenter M9 L8 XL7">
-              <div>
-                {% block article_body %}{% endblock %}
+            <div class="o-grid-row">
+              <div data-o-grid-colspan="12 S11 Scenter M9 L8 XL7">
+                <div>
+                  {% block article_body %}{% endblock %}
+                </div>
               </div>
             </div>
           </div>
 
           <footer class="o-typography-footer" itemprop="publisher" itemscope itemtype="https://schema.org/Organization">
-            <small><a href="http://www.ft.com/servicestools/help/copyright" data-trackable="link-copyright">Copyright</a>
-  					<span itemprop="name">The Financial Times</span> Limited {{ now() | strftime('%Y') }}. All rights reserved. You may share using our article tools. Please don't cut articles from FT.com and redistribute by email or post to the web.</small>
+            <div class="o-grid-container">
+              <div class="o-grid-row">
+                <div data-o-grid-colspan="12 S11 Scenter M9 L8 XL7">
+                  <small><a href="http://www.ft.com/servicestools/help/copyright" data-trackable="link-copyright">Copyright</a>
+                   <span itemprop="name">The Financial Times</span> Limited {{ now() | strftime('%Y') }}. All rights reserved. You may share using our article tools. Please don't cut articles from FT.com and redistribute by email or post to the web.</small>
+                </div>
+              </div>
+            </div>
           </footer>
+
         </div>
       </article>
     </main>


### PR DESCRIPTION
This fixes the footer which was sticking out to the side, by applying the same positioning to it as to the body copy. 

And removes some of the default text in case of accidental commits. 
Will leave the picture for illustrative purposes. 


