### PR TITLE
Edit share options and description meta tag

### DIFF
--- a/config/article.js
+++ b/config/article.js
@@ -65,17 +65,25 @@ export default () => ({ // eslint-disable-line
   // General social
   // socialImage: '',
   // socialHeadline: '',
-  // socialSummary: '',
+  // socialDescription: '',
+  // twitterCreator: '@author's_account', // shows up in summary_large_image cards
 
-  // TWITTER
-  // twitterImage: '',
-  // twitterCreator: '@individual's_account',
+  // TWEET BUTTON CUSTOM TEXT
   // tweetText: '',
+  // twitterRelatedAccounts: ['authors_account_here', 'ftdata'], // Twitter lists these as suggested accounts to follow after a user tweets (do not include @)
+
+  // Fill out the Facebook/Twitter metadata sections below if you want to
+  // override the "General social" options above
+
+  // TWITTER METADATA (for Twitter cards)
+  // twitterImage: '',
   // twitterHeadline: '',
+  // twitterDescription: '',
 
   // FACEBOOK
   // facebookImage: '',
   // facebookHeadline: '',
+  // facebookDescription: '',
 
   tracking: {
 

--- a/config/article.js
+++ b/config/article.js
@@ -65,13 +65,13 @@ export default () => ({ // eslint-disable-line
   // General social
   // socialImage: '',
   // socialHeadline: '',
-  // socialSummary:  '',
+  // socialSummary: '',
 
   // TWITTER
   // twitterImage: '',
   // twitterCreator: '@individual's_account',
-  // tweetText:  '',
-  // twitterHeadline:  '',
+  // tweetText: '',
+  // twitterHeadline: '',
 
   // FACEBOOK
   // facebookImage: '',

--- a/views/includes/footer.html
+++ b/views/includes/footer.html
@@ -1,133 +1,133 @@
 <footer class="o-footer o-footer--theme-dark" data-o-component="o-footer" data-o-footer--no-js="">
-	<div class="o-footer__container">
+  <div class="o-footer__container">
 
-		<div class="o-footer__row">
-			<nav class="o-footer__matrix" role="navigation" aria-label="Useful links">
-				<div class="o-footer__matrix-group o-footer__matrix-group--1">
-					<h6 class="o-footer__matrix-title">
-						Support
-					</h6>
-					<div class="o-footer__matrix-content" id="o-footer-section-0">
-							<div class="o-footer__matrix-column">
-									<a class="o-footer__matrix-link" href="//www.ft.com/help">Help</a>
-									<a class="o-footer__matrix-link" href="//www.ft.com/aboutus">About Us</a>
-							</div>
-					</div>
-				</div>
-				<div class="o-footer__matrix-group o-footer__matrix-group--1">
-					<h6 class="o-footer__matrix-title">
-						Legal &amp; Privacy
-					</h6>
-					<div class="o-footer__matrix-content" id="o-footer-section-1">
-							<div class="o-footer__matrix-column">
-									<a class="o-footer__matrix-link" href="//www.ft.com/servicestools/help/terms">Terms &amp; Conditions</a>
-									<a class="o-footer__matrix-link" href="//www.ft.com/servicestools/help/privacy">Privacy</a>
-									<a class="o-footer__matrix-link" href="//www.ft.com/cookiepolicy">Cookies</a>
-									<a class="o-footer__matrix-link" href="//www.ft.com/servicestools/help/copyright">Copyright</a>
-							</div>
-					</div>
-				</div>
-				<div class="o-footer__matrix-group o-footer__matrix-group--2">
-					<h6 class="o-footer__matrix-title" aria-controls="o-footer-section-2">
-						Services
-					</h6>
-					<div class="o-footer__matrix-content" id="o-footer-section-2">
-							<div class="o-footer__matrix-column">
-									<a class="o-footer__matrix-link" href="//sub.ft.com/spa_5">Individual Subscriptions</a>
-									<a class="o-footer__matrix-link" href="//enterprise.ft.com/en-gb/services/group-subscriptions/">Group Subscriptions</a>
-									<a class="o-footer__matrix-link" href="//enterprise.ft.com/en-gb/services/republishing/">Republishing</a>
-									<a class="o-footer__matrix-link" href="//www.businessesforsale.com/ft2/notices">Contracts &amp; Tenders</a>
-									<a class="o-footer__matrix-link" href="//commerce.uk.reuters.com/purchase/mostPopular.do?rpc&amp;#x3D;471">Analysts Research</a>
-							</div>
-							<div class="o-footer__matrix-column">
-									<a class="o-footer__matrix-link" href="//www.exec-appointments.com/">Executive Job Search</a>
-									<a class="o-footer__matrix-link" aria-label="Advertise with the F T" href="//fttoolkit.co.uk/d/">Advertise with the FT</a>
-									<a class="o-footer__matrix-link" aria-label="Follow the F T on Twitter" href="//twitter.com/ft">Follow the FT on Twitter</a>
-							</div>
-					</div>
-				</div>
-				<div class="o-footer__matrix-group o-footer__matrix-group--2">
-					<h6 class="o-footer__matrix-title" aria-controls="o-footer-section-3">
-						Tools
-					</h6>
-					<div class="o-footer__matrix-content" id="o-footer-section-3">
-							<div class="o-footer__matrix-column">
-									<a class="o-footer__matrix-link" href="//markets.ft.com/data/portfolio/dashboard">Portfolio</a>
-									<a class="o-footer__matrix-link" href="//ftepaper.ft.com">Today&apos;s Paper</a>
-									<a class="o-footer__matrix-link" href="//markets.ft.com/data/alerts/">Alerts Hub</a>
-									<a class="o-footer__matrix-link" href="//lexicon.ft.com/">Lexicon</a>
-									<a class="o-footer__matrix-link" href="//rankings.ft.com/businessschoolrankings/global-mba-ranking-2016">MBA Rankings</a>
-							</div>
-							<div class="o-footer__matrix-column">
-									<a class="o-footer__matrix-link" href="//markets.ft.com/Research/Economic-Calendar">Economic Calendar</a>
-									<a class="o-footer__matrix-link" href="//nbe.ft.com/nbe/profile.cfm">Newsletters</a>
-									<a class="o-footer__matrix-link" href="//markets.ft.com/research/Markets/Currencies?segid&amp;#x3D;70113">Currency Converter</a>
-									<a class="o-footer__matrix-link" aria-label="E-books" href="//www.ft.com/ebooks">Ebooks</a>
-							</div>
-					</div>
-				</div>
-				<div class="o-footer__matrix-group o-footer__matrix-group--6">
-					<h6 class="o-footer__matrix-title" aria-controls="o-footer-section-4">
-						More from FT Group
-					</h6>
-					<div class="o-footer__matrix-content" id="o-footer-section-4">
-							<div class="o-footer__matrix-column">
-									<a class="o-footer__matrix-link" href="//www.agendaweek.com/">Agenda</a>
-									<a class="o-footer__matrix-link" href="//www.analyseafrica.com/">Analyse Africa</a>
-									<a class="o-footer__matrix-link" href="//www.boardiq.com/">Board IQ</a>
-									<a class="o-footer__matrix-link" href="//www.ftiecla.com/">Corporate Learning Alliance</a>
-									<a class="o-footer__matrix-link" href="//www.dpn-online.com/">DPN: Deutsche Pensions &amp; Investment Nachrichten</a>
-							</div>
-							<div class="o-footer__matrix-column">
-									<a class="o-footer__matrix-link" href="//www.execsense.com/">ExecSense</a>
-									<a class="o-footer__matrix-link" href="//www.fdiintelligence.com/">FDI Intelligence</a>
-									<a class="o-footer__matrix-link" href="//financialadvisoriq.com/">Financial Advisor IQ</a>
-									<a class="o-footer__matrix-link" aria-label="F T Chinese" href="//www.ftchinese.com/">FT Chinese</a>
-									<a class="o-footer__matrix-link" aria-label="F T Live" href="//live.ft.com/">FT Live</a>
-							</div>
-							<div class="o-footer__matrix-column">
-									<a class="o-footer__matrix-link" aria-label="F T Property Listings" href="//propertylistings.ft.com/">FT Property Listings</a>
-									<a class="o-footer__matrix-link" aria-label="F T Advisor" href="//www.ftadviser.com/">FT Advisor</a>
-									<a class="o-footer__matrix-link" href="//www.fundfire.com/">Fund Fire</a>
-									<a class="o-footer__matrix-link" href="//www.globalriskregulator.com/">Global Risk Regulator</a>
-									<a class="o-footer__matrix-link" href="//howtospendit.ft.com/">How to Spend It</a>
-							</div>
-							<div class="o-footer__matrix-column">
-									<a class="o-footer__matrix-link" href="//www.ignites.com/">Ignites</a>
-									<a class="o-footer__matrix-link" href="//www.ignitesasia.com/">Ignites Asia</a>
-									<a class="o-footer__matrix-link" href="//www.igniteseurope.com/">Ignites Europe</a>
-									<a class="o-footer__matrix-link" href="//www.investorschronicle.co.uk/">Investors Chronicle</a>
-									<a class="o-footer__matrix-link" href="//www.mandatewire.com/">Mandate Wire</a>
-							</div>
-							<div class="o-footer__matrix-column">
-									<a class="o-footer__matrix-link" href="//www.nyif.com/">New York Insitute of Finance</a>
-									<a class="o-footer__matrix-link" href="//www.non-execs.com/">Non Executive Directors Club</a>
-									<a class="o-footer__matrix-link" href="//www.pensions-expert.com/">Pensions Expert</a>
-									<a class="o-footer__matrix-link" href="//www.pwmnet.com/">Professional Wealth Management</a>
-									<a class="o-footer__matrix-link" href="//the125.ft.com/">125 Club</a>
-							</div>
-							<div class="o-footer__matrix-column">
-									<a class="o-footer__matrix-link" href="//www.thebanker.com/">The Banker</a>
-									<a class="o-footer__matrix-link" href="//www.thebankerdatabase.com/">The Banker Database</a>
-									<a class="o-footer__matrix-link" href="//www.thisisafricaonline.com/">This is Africa</a>
-							</div>
-					</div>
-				</div>
-			</nav>
-		</div>
+    <div class="o-footer__row">
+      <nav class="o-footer__matrix" role="navigation" aria-label="Useful links">
+        <div class="o-footer__matrix-group o-footer__matrix-group--1">
+          <h6 class="o-footer__matrix-title">
+            Support
+          </h6>
+          <div class="o-footer__matrix-content" id="o-footer-section-0">
+              <div class="o-footer__matrix-column">
+                  <a class="o-footer__matrix-link" href="//www.ft.com/help">Help</a>
+                  <a class="o-footer__matrix-link" href="//www.ft.com/aboutus">About Us</a>
+              </div>
+          </div>
+        </div>
+        <div class="o-footer__matrix-group o-footer__matrix-group--1">
+          <h6 class="o-footer__matrix-title">
+            Legal &amp; Privacy
+          </h6>
+          <div class="o-footer__matrix-content" id="o-footer-section-1">
+              <div class="o-footer__matrix-column">
+                  <a class="o-footer__matrix-link" href="//www.ft.com/servicestools/help/terms">Terms &amp; Conditions</a>
+                  <a class="o-footer__matrix-link" href="//www.ft.com/servicestools/help/privacy">Privacy</a>
+                  <a class="o-footer__matrix-link" href="//www.ft.com/cookiepolicy">Cookies</a>
+                  <a class="o-footer__matrix-link" href="//www.ft.com/servicestools/help/copyright">Copyright</a>
+              </div>
+          </div>
+        </div>
+        <div class="o-footer__matrix-group o-footer__matrix-group--2">
+          <h6 class="o-footer__matrix-title" aria-controls="o-footer-section-2">
+            Services
+          </h6>
+          <div class="o-footer__matrix-content" id="o-footer-section-2">
+              <div class="o-footer__matrix-column">
+                  <a class="o-footer__matrix-link" href="//sub.ft.com/spa_5">Individual Subscriptions</a>
+                  <a class="o-footer__matrix-link" href="//enterprise.ft.com/en-gb/services/group-subscriptions/">Group Subscriptions</a>
+                  <a class="o-footer__matrix-link" href="//enterprise.ft.com/en-gb/services/republishing/">Republishing</a>
+                  <a class="o-footer__matrix-link" href="//www.businessesforsale.com/ft2/notices">Contracts &amp; Tenders</a>
+                  <a class="o-footer__matrix-link" href="//commerce.uk.reuters.com/purchase/mostPopular.do?rpc&amp;#x3D;471">Analysts Research</a>
+              </div>
+              <div class="o-footer__matrix-column">
+                  <a class="o-footer__matrix-link" href="//www.exec-appointments.com/">Executive Job Search</a>
+                  <a class="o-footer__matrix-link" aria-label="Advertise with the F T" href="//fttoolkit.co.uk/d/">Advertise with the FT</a>
+                  <a class="o-footer__matrix-link" aria-label="Follow the F T on Twitter" href="//twitter.com/ft">Follow the FT on Twitter</a>
+              </div>
+          </div>
+        </div>
+        <div class="o-footer__matrix-group o-footer__matrix-group--2">
+          <h6 class="o-footer__matrix-title" aria-controls="o-footer-section-3">
+            Tools
+          </h6>
+          <div class="o-footer__matrix-content" id="o-footer-section-3">
+              <div class="o-footer__matrix-column">
+                  <a class="o-footer__matrix-link" href="//markets.ft.com/data/portfolio/dashboard">Portfolio</a>
+                  <a class="o-footer__matrix-link" href="//ftepaper.ft.com">Today&apos;s Paper</a>
+                  <a class="o-footer__matrix-link" href="//markets.ft.com/data/alerts/">Alerts Hub</a>
+                  <a class="o-footer__matrix-link" href="//lexicon.ft.com/">Lexicon</a>
+                  <a class="o-footer__matrix-link" href="//rankings.ft.com/businessschoolrankings/global-mba-ranking-2016">MBA Rankings</a>
+              </div>
+              <div class="o-footer__matrix-column">
+                  <a class="o-footer__matrix-link" href="//markets.ft.com/Research/Economic-Calendar">Economic Calendar</a>
+                  <a class="o-footer__matrix-link" href="//nbe.ft.com/nbe/profile.cfm">Newsletters</a>
+                  <a class="o-footer__matrix-link" href="//markets.ft.com/research/Markets/Currencies?segid&amp;#x3D;70113">Currency Converter</a>
+                  <a class="o-footer__matrix-link" aria-label="E-books" href="//www.ft.com/ebooks">Ebooks</a>
+              </div>
+          </div>
+        </div>
+        <div class="o-footer__matrix-group o-footer__matrix-group--6">
+          <h6 class="o-footer__matrix-title" aria-controls="o-footer-section-4">
+            More from FT Group
+          </h6>
+          <div class="o-footer__matrix-content" id="o-footer-section-4">
+              <div class="o-footer__matrix-column">
+                  <a class="o-footer__matrix-link" href="//www.agendaweek.com/">Agenda</a>
+                  <a class="o-footer__matrix-link" href="//www.analyseafrica.com/">Analyse Africa</a>
+                  <a class="o-footer__matrix-link" href="//www.boardiq.com/">Board IQ</a>
+                  <a class="o-footer__matrix-link" href="//www.ftiecla.com/">Corporate Learning Alliance</a>
+                  <a class="o-footer__matrix-link" href="//www.dpn-online.com/">DPN: Deutsche Pensions &amp; Investment Nachrichten</a>
+              </div>
+              <div class="o-footer__matrix-column">
+                  <a class="o-footer__matrix-link" href="//www.execsense.com/">ExecSense</a>
+                  <a class="o-footer__matrix-link" href="//www.fdiintelligence.com/">FDI Intelligence</a>
+                  <a class="o-footer__matrix-link" href="//financialadvisoriq.com/">Financial Advisor IQ</a>
+                  <a class="o-footer__matrix-link" aria-label="F T Chinese" href="//www.ftchinese.com/">FT Chinese</a>
+                  <a class="o-footer__matrix-link" aria-label="F T Live" href="//live.ft.com/">FT Live</a>
+              </div>
+              <div class="o-footer__matrix-column">
+                  <a class="o-footer__matrix-link" aria-label="F T Property Listings" href="//propertylistings.ft.com/">FT Property Listings</a>
+                  <a class="o-footer__matrix-link" aria-label="F T Advisor" href="//www.ftadviser.com/">FT Advisor</a>
+                  <a class="o-footer__matrix-link" href="//www.fundfire.com/">Fund Fire</a>
+                  <a class="o-footer__matrix-link" href="//www.globalriskregulator.com/">Global Risk Regulator</a>
+                  <a class="o-footer__matrix-link" href="//howtospendit.ft.com/">How to Spend It</a>
+              </div>
+              <div class="o-footer__matrix-column">
+                  <a class="o-footer__matrix-link" href="//www.ignites.com/">Ignites</a>
+                  <a class="o-footer__matrix-link" href="//www.ignitesasia.com/">Ignites Asia</a>
+                  <a class="o-footer__matrix-link" href="//www.igniteseurope.com/">Ignites Europe</a>
+                  <a class="o-footer__matrix-link" href="//www.investorschronicle.co.uk/">Investors Chronicle</a>
+                  <a class="o-footer__matrix-link" href="//www.mandatewire.com/">Mandate Wire</a>
+              </div>
+              <div class="o-footer__matrix-column">
+                  <a class="o-footer__matrix-link" href="//www.nyif.com/">New York Insitute of Finance</a>
+                  <a class="o-footer__matrix-link" href="//www.non-execs.com/">Non Executive Directors Club</a>
+                  <a class="o-footer__matrix-link" href="//www.pensions-expert.com/">Pensions Expert</a>
+                  <a class="o-footer__matrix-link" href="//www.pwmnet.com/">Professional Wealth Management</a>
+                  <a class="o-footer__matrix-link" href="//the125.ft.com/">125 Club</a>
+              </div>
+              <div class="o-footer__matrix-column">
+                  <a class="o-footer__matrix-link" href="//www.thebanker.com/">The Banker</a>
+                  <a class="o-footer__matrix-link" href="//www.thebankerdatabase.com/">The Banker Database</a>
+                  <a class="o-footer__matrix-link" href="//www.thisisafricaonline.com/">This is Africa</a>
+              </div>
+          </div>
+        </div>
+      </nav>
+    </div>
 
-		<div class="o-footer__copyright" role="contentinfo">
-			<small>
-				Markets data delayed by at least 15 minutes. &#xA9; THE FINANCIAL TIMES LTD {{ now() | strftime('%Y') }}.
-				<abbr title="Financial Times" aria-label="F T">FT</abbr> and &#x2018;Financial Times&#x2019; are trademarks of The Financial Times Ltd.<br>
-				The Financial Times and its journalism are subject to a self-regulation regime under the <a href="http://www.ft.com/editorialcode" aria-label="F T Editorial Code of Practice">FT Editorial Code of Practice</a>.
-			</small>
-		</div>
+    <div class="o-footer__copyright" role="contentinfo">
+      <small>
+        Markets data delayed by at least 15 minutes. &#xA9; THE FINANCIAL TIMES LTD {{ now() | strftime('%Y') }}.
+        <abbr title="Financial Times" aria-label="F T">FT</abbr> and &#x2018;Financial Times&#x2019; are trademarks of The Financial Times Ltd.<br>
+        The Financial Times and its journalism are subject to a self-regulation regime under the <a href="http://www.ft.com/editorialcode" aria-label="F T Editorial Code of Practice">FT Editorial Code of Practice</a>.
+      </small>
+    </div>
 
-	</div>
-	<div class="o-footer__brand">
-		<div class="o-footer__container">
-			<div class="o-footer__brand-logo"></div>
-		</div>
-	</div>
+  </div>
+  <div class="o-footer__brand">
+    <div class="o-footer__container">
+      <div class="o-footer__brand-logo"></div>
+    </div>
+  </div>
 </footer>

--- a/views/includes/header.html
+++ b/views/includes/header.html
@@ -1,13 +1,13 @@
 <header class="o-header o-header--simple" data-o-component="o-header" data-o-header--no-js="">
-	<div class="o-header__row o-header__top">
-		<div class="o-header__container">
-			<div class="o-header__top-wrapper">
-				<div class="o-header__top-column o-header__top-column--center">
-					<a class="o-header__top-logo" href="http://www.ft.com/" title="Go to Financial Times homepage">
-						<span class="o-header__visually-hidden">Financial Times</span>
-					</a>
-				</div>
-			</div>
-		</div>
-	</div>
+  <div class="o-header__row o-header__top">
+    <div class="o-header__container">
+      <div class="o-header__top-wrapper">
+        <div class="o-header__top-column o-header__top-column--center">
+          <a class="o-header__top-logo" href="http://www.ft.com/" title="Go to Financial Times homepage">
+            <span class="o-header__visually-hidden">Financial Times</span>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
 </header>

--- a/views/includes/html-head.html
+++ b/views/includes/html-head.html
@@ -145,8 +145,8 @@
 <meta property="og:title" content="{{ facebookHeadline | default (socialHeadline) | default(headline, true) }}">
 
 <meta name="description" content="{{ description }}">
-<meta name="twitter:description" content="{{ description }}">
-<meta property="og:description" content="{{ description }}">
+<meta name="twitter:description" content="{{ twitterDescription | default(socialDescription) | default(description) }}">
+<meta property="og:description" content="{{ facebookDescription | default(socialDescription) | default(description) }}">
 
 <link rel="canonical" href="{{ url }}">
 <meta name="twitter:url" content="{{ url }}">

--- a/views/includes/share.html
+++ b/views/includes/share.html
@@ -3,7 +3,7 @@
     <div data-o-component="o-share" class="o-share">
       <ul>
         <li class="o-share__action o-share__action--twitter">
-          <a href="https://twitter.com/intent/tweet?url={{ url }}&amp;text={{ tweetText }}&amp;related={{ topic.name }}&amp;via=FT" rel="noopener"><i>Twitter</i></a>
+          <a href="https://twitter.com/intent/tweet?url={{ url }}&amp;text={{ tweetText | default(twitterHeadline) | default(socialHeadline) | default(headline) }}{% if twitterRelatedAccounts %}&amp;related={{ twitterRelatedAccounts | join(',') }}{% endif %}&amp;via=FT" rel="noopener"><i>Twitter</i></a>
         </li>
         <li class="o-share__action o-share__action--facebook">
           <a href="http://www.facebook.com/sharer.php?u={{ url }}" rel="noopener"><i>Facebook</i></a>

--- a/views/includes/share.html
+++ b/views/includes/share.html
@@ -1,17 +1,17 @@
 <div class="article__share article__share--top n-util-clearfix" data-trackable="share | top">
-	<div class="container">
-		<div data-o-component="o-share" class="o-share">
-			<ul>
-				<li class="o-share__action o-share__action--twitter">
-					<a href="https://twitter.com/intent/tweet?url={{ url }}&amp;related={{ topic.name }}&amp;via=FT" rel="noopener"><i>Twitter</i></a>
-				</li>
-				<li class="o-share__action o-share__action--facebook">
-					<a href="http://www.facebook.com/sharer.php?u={{ url }}" rel="noopener"><i>Facebook</i></a>
-				</li>
-				<li class="o-share__action o-share__action--linkedin">
-					<a href="https://www.linkedin.com/shareArticle?mini=true&amp;url={{ url }}&amp;source=Financial%20Times" rel="noopener"><i>LinkedIn</i></a>
-				</li>
-			</ul>
-		</div>
-	</div>
+  <div class="container">
+    <div data-o-component="o-share" class="o-share">
+      <ul>
+        <li class="o-share__action o-share__action--twitter">
+          <a href="https://twitter.com/intent/tweet?url={{ url }}&amp;text={{ tweetText }}&amp;related={{ topic.name }}&amp;via=FT" rel="noopener"><i>Twitter</i></a>
+        </li>
+        <li class="o-share__action o-share__action--facebook">
+          <a href="http://www.facebook.com/sharer.php?u={{ url }}" rel="noopener"><i>Facebook</i></a>
+        </li>
+        <li class="o-share__action o-share__action--linkedin">
+          <a href="https://www.linkedin.com/shareArticle?mini=true&amp;url={{ url }}&amp;source=Financial%20Times" rel="noopener"><i>LinkedIn</i></a>
+        </li>
+      </ul>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
Tweet button text comes from the following fields (in order of presence):
    - `tweetText`
    - `twitterHeadline`
    - `socialHeadline`
    - `headline`

Related accounts can now be added to the tweet button using the `twitterRelatedAccounts` variable — Twitter lists these as suggested accounts to follow after a user tweets from the popup dialog box.

Description meta tag comes from `description` field.
    
Twitter and Facebook description meta tags come from `twitterDescription` and `facebookDescription`, `socialDescription` (if separate twitter and facebook descriptions don't exist) then `description` (if none of the above exist).