### PR TITLE
Hide comments from the pa11y accessibility checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,8 +65,8 @@
   "private": true,
   "scripts": {
     "build": "webpack -p --env=production",
-    "check-accessibility": "pa11y --threshold 100 $(ft-graphics-deploy --get-commit-url)",
-    "check-accessibility:preview": "pa11y --threshold 100 $(ft-graphics-deploy --preview --get-commit-url)",
+    "check-accessibility": "pa11y --hide-elements '.o-comments' --threshold 100 $(ft-graphics-deploy --get-commit-url)",
+    "check-accessibility:preview": "pa11y --hide-elements '.o-comments' --threshold 100 $(ft-graphics-deploy --preview --get-commit-url)",
     "clean": "rm -rf dist",
     "deploy": "ft-graphics-deploy --assets-prefix=https://ig.ft.com/v2/__assets/",
     "postinstall": "bower install --allow-root",


### PR DESCRIPTION
On already published pages, comments can cause the pa11y checks to fail. 

This change excludes comments from these checks so that builds to these already published changes can pass. 