### PR TITLE
Only change "core" to "enhanced" if cutsTheMustard

### DIFF
--- a/views/includes/html-head.html
+++ b/views/includes/html-head.html
@@ -62,9 +62,9 @@
 <script src="https://cdn.polyfill.io/v2/polyfill.min.js?callback=client&amp;features=default,fetch"></script>
 
 <!-- Add CTM checks -->
-<script type="text/javascript">
-  window.cutsTheMustard = ('querySelector' in document && 'localStorage' in window && 'addEventListener' in window && typeof Function.prototype.bind !== 'undefined')
-  document.documentElement.className = document.documentElement.className.replace(/core/g, 'enhanced');
+<script>
+  cutsTheMustard = ('querySelector' in document && 'localStorage' in window && 'addEventListener' in window && typeof Function.prototype.bind !== 'undefined');
+  if (cutsTheMustard) document.documentElement.className = document.documentElement.className.replace(/core/g, 'enhanced');
 </script>
 
 {%- if flags.analytics %}
@@ -76,7 +76,7 @@
   {% if tracking.micrositeName %}
 <meta property="ft.track:microsite_name" content="{{ tracking.micrositeName }}"/>
   {% endif %}
-<script type="text/javascript">
+<script>
   function oTrackinginit() {
     var oTracking = Origami['o-tracking'];
 
@@ -118,7 +118,7 @@
 {% endif -%}
 
 <!-- Add Origami Build Service -->
-<script type="text/javascript">
+<script>
   (function(src) {
     if (cutsTheMustard) {
       var o = document.createElement('script');


### PR DESCRIPTION
Looks like we've been changing "core" to "enhanced" for **all** JS-supporting browsers, instead of just for CTM-passing browsers.

This PR fixes it.

Also: removes `type="text/javascript"` from script tags. It's a relic from the past and should now be considered an antipattern. Using `type="text/javascript"` is [officially](https://www.w3.org/TR/html5/scripting-1.html#the-script-element) not needed in HTML5, and its presence has had no effect on any browser in the wild ever. The only reason to add a type attribute is if you **don't** want to treat the script as JavaScript, like when you want it to contain config JSON or a template or something.