### PR TITLE
add o-typography-standfirst class to subhead

### DIFF
--- a/views/includes/article-head.html
+++ b/views/includes/article-head.html
@@ -4,7 +4,7 @@
 
 <h1 class="o-typography-headline" itemprop="headline">{{ headline | md(true) }}</h1>
 
-<p>
+<p class="o-typography-standfirst">
   {{ summary | md(true) }}
   {% if relatedArticle %}
   <a href="{{ relatedArticle.url }}" class="o-typography-link">{{ relatedArticle.text }}</a>


### PR DESCRIPTION
Added the `o-typography-standfirst` class to the standfirst on the page to match the rest of the website.

The gap between the headline and the current subhead got wider with the updated origami dependencies, which made the discrepancy more obvious than before.