### PR TITLE
Add fetch polyfill.

### DIFF
--- a/views/includes/html-head.html
+++ b/views/includes/html-head.html
@@ -59,7 +59,7 @@
 {# Prioritised JavaScript #}
 
 <!-- Add polyfill service -->
-<script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
+<script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,fetch"></script>
 
 <!-- Add CTM checks -->
 <script>


### PR DESCRIPTION
In [a previous PR](https://github.com/ft-interactive/starter-kit/pull/161) I removed babel-polyfill to reduce bundle size and possible conflicts with polyfill.io. I also removed the `features=default,fetch` param from the polyfill.io request as I incorrectly thought all required polyfills for a browser are included by default, which they are not.

https://github.com/ft-interactive/starter-kit/pull/161#discussion-diff-163408639L62
https://polyfill.io/v2/docs/features/#default-sets

Somehow I managed to trick myself into thinking `fetch` was polyfilled with a [Trump quote demo](https://github.com/ft-interactive/starter-kit/pull/161) which it was not.  
<img width="1326" alt="screen shot 2018-01-24 at 11 06 55" src="https://user-images.githubusercontent.com/10405691/35329557-3e159ce6-00f8-11e8-99fa-00fdb9fa0ee1.png">
But it is now with these changes:
<img width="1327" alt="screen shot 2018-01-24 at 11 04 58" src="https://user-images.githubusercontent.com/10405691/35329577-4d4a996e-00f8-11e8-88a0-06eeec3a4990.png">
