### PR TITLE
A11y

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,9 +57,9 @@ jobs:
           command: |
             if [ "$PREVIEW" == "true" ]
             then
-              npm run check-accessibility:preview
+              npm run a11y:preview
             else
-              npm run check-accessibility
+              npm run a11y
             fi
       - run:
           name: General QA checks

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ You can run the following tasks from within your project directory:
 - `npm start` — starts up a development server and opens your app in a web browser. The dev server will automatically reload your browser when files change.
 - `npm run build` — builds your app and puts it in the `dist` folder.
 - `npm run deploy` — deploys the contents of your `dist` folder to an appropriate location on S3. (You usually don't need to run this yourself — it is run automatically by CircleCI.)
+- `npm run a11y:local` - checks accessibility of your app running locally
 
 (You can find a few other, less interesting tasks defined in [`package.json`](package.json).)
 

--- a/client/index.html
+++ b/client/index.html
@@ -49,7 +49,7 @@ beginning of this article.
 <figure class="graphic graphic-b-1 graphic-pad-1">
   <img alt="" src="https://image.webservices.ft.com/v1/images/raw/http%3A%2F%2Fcom.ft.imagepublish.prod.s3.amazonaws.com%2Fc4bf0be4-7c15-11e4-a7b8-00144feabdc0?source=ig&fit=scale-down&width=700"></img>
     <figcaption class="o-typography-caption">
-    <a class="o-typography-link" href="#void">&#xA9;Credit person</a> George Orwell at his typewriter
+    <a class="o-typography-link" href="#RELEVANT_LINK">&#xA9;Credit person</a> George Orwell at his typewriter
   </figcaption>
 </figure>
 

--- a/client/index.html
+++ b/client/index.html
@@ -49,7 +49,7 @@ beginning of this article.
 <figure class="graphic graphic-b-1 graphic-pad-1">
   <img alt="" src="https://image.webservices.ft.com/v1/images/raw/http%3A%2F%2Fcom.ft.imagepublish.prod.s3.amazonaws.com%2Fc4bf0be4-7c15-11e4-a7b8-00144feabdc0?source=ig&fit=scale-down&width=700"></img>
     <figcaption class="o-typography-caption">
-    <a class="o-typography-link" href="#RELEVANT_LINK">&#xA9;Credit person</a> George Orwell at his typewriter
+    <a class="o-typography-link" href="http://foo.bar">&#xA9;Credit person</a> George Orwell at his typewriter
   </figcaption>
 </figure>
 

--- a/package.json
+++ b/package.json
@@ -82,8 +82,9 @@
   "private": true,
   "scripts": {
     "build": "webpack -p --env=production",
-    "check-accessibility": "pa11y --hide-elements '.o-comments' --threshold 100 $(ft-graphics-deploy --get-commit-url)",
-    "check-accessibility:preview": "pa11y --hide-elements '.o-comments' --threshold 100 $(ft-graphics-deploy --preview --get-commit-url)",
+    "a11y": "pa11y --ignore \"warning;notice\" --hide-elements \"iframe[src*=google],iframe[id*=google],.o-comments\" --threshold 100 $(ft-graphics-deploy --get-commit-url)",
+    "a11y:preview": "pa11y --ignore \"warning;notice\" --hide-elements \"iframe[src*=google],iframe[id*=google],.o-comments\" --threshold 100 $(ft-graphics-deploy --preview --get-commit-url)",
+    "a11y:local": " pa11y --ignore \"warning;notice\" localhost:8080 --hide-elements \"iframe[src*=google],iframe[id*=google],.o-comments\"",
     "clean": "rm -rf dist",
     "deploy": "ft-graphics-deploy --assets-prefix=https://ig.ft.com/v2/__assets/",
     "postinstall": "bower install --allow-root",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "build": "webpack -p --env=production",
     "a11y": "pa11y --ignore \"warning;notice\" --hide-elements \"iframe[src*=google],iframe[id*=google],.o-comments\" --threshold 100 $(ft-graphics-deploy --get-commit-url)",
     "a11y:preview": "pa11y --ignore \"warning;notice\" --hide-elements \"iframe[src*=google],iframe[id*=google],.o-comments\" --threshold 100 $(ft-graphics-deploy --preview --get-commit-url)",
-    "a11y:local": " pa11y --ignore \"warning;notice\" localhost:8080 --hide-elements \"iframe[src*=google],iframe[id*=google],.o-comments\"",
+    "a11y:local": "pa11y --ignore \"warning;notice\" localhost:8080 --hide-elements \"iframe[src*=google],iframe[id*=google],.o-comments\"",
     "clean": "rm -rf dist",
     "deploy": "ft-graphics-deploy --assets-prefix=https://ig.ft.com/v2/__assets/",
     "postinstall": "bower install --allow-root",

--- a/views/includes/footer.html
+++ b/views/includes/footer.html
@@ -4,9 +4,9 @@
     <div class="o-footer__row">
       <nav class="o-footer__matrix" role="navigation" aria-label="Useful links">
         <div class="o-footer__matrix-group o-footer__matrix-group--1">
-          <h6 class="o-footer__matrix-title">
+          <div class="o-footer__matrix-title">
             Support
-          </h6>
+          </div>
           <div class="o-footer__matrix-content" id="o-footer-section-0">
               <div class="o-footer__matrix-column">
                   <a class="o-footer__matrix-link" href="//www.ft.com/help">Help</a>
@@ -15,9 +15,9 @@
           </div>
         </div>
         <div class="o-footer__matrix-group o-footer__matrix-group--1">
-          <h6 class="o-footer__matrix-title">
+          <div class="o-footer__matrix-title">
             Legal &amp; Privacy
-          </h6>
+          </div>
           <div class="o-footer__matrix-content" id="o-footer-section-1">
               <div class="o-footer__matrix-column">
                   <a class="o-footer__matrix-link" href="//www.ft.com/servicestools/help/terms">Terms &amp; Conditions</a>
@@ -28,9 +28,9 @@
           </div>
         </div>
         <div class="o-footer__matrix-group o-footer__matrix-group--2">
-          <h6 class="o-footer__matrix-title" aria-controls="o-footer-section-2">
+          <div class="o-footer__matrix-title" aria-controls="o-footer-section-2">
             Services
-          </h6>
+          </div>
           <div class="o-footer__matrix-content" id="o-footer-section-2">
               <div class="o-footer__matrix-column">
                   <a class="o-footer__matrix-link" href="//sub.ft.com/spa_5">Individual Subscriptions</a>
@@ -47,9 +47,9 @@
           </div>
         </div>
         <div class="o-footer__matrix-group o-footer__matrix-group--2">
-          <h6 class="o-footer__matrix-title" aria-controls="o-footer-section-3">
+          <div class="o-footer__matrix-title" aria-controls="o-footer-section-3">
             Tools
-          </h6>
+          </div>
           <div class="o-footer__matrix-content" id="o-footer-section-3">
               <div class="o-footer__matrix-column">
                   <a class="o-footer__matrix-link" href="//markets.ft.com/data/portfolio/dashboard">Portfolio</a>
@@ -67,9 +67,9 @@
           </div>
         </div>
         <div class="o-footer__matrix-group o-footer__matrix-group--6">
-          <h6 class="o-footer__matrix-title" aria-controls="o-footer-section-4">
+          <div class="o-footer__matrix-title" aria-controls="o-footer-section-4">
             More from FT Group
-          </h6>
+          </div>
           <div class="o-footer__matrix-content" id="o-footer-section-4">
               <div class="o-footer__matrix-column">
                   <a class="o-footer__matrix-link" href="//www.agendaweek.com/">Agenda</a>

--- a/views/includes/share.html
+++ b/views/includes/share.html
@@ -3,16 +3,16 @@
     <div data-o-component="o-share" class="o-share">
       <ul>
         <li class="o-share__action o-share__action--twitter">
-          <a href="https://twitter.com/intent/tweet?url={{ url }}&amp;text={{ tweetText | default(twitterHeadline) | default(socialHeadline) | default(headline) }}{% if twitterRelatedAccounts %}&amp;related={{ twitterRelatedAccounts | join(',') }}{% endif %}&amp;via=FinancialTimes" rel="noopener"><i><span cass="o-header--visually-hidden"></span>Share on Twitter</i></a>
+          <a href="https://twitter.com/intent/tweet?url={{ url }}&amp;text={{ tweetText | default(twitterHeadline) | default(socialHeadline) | default(headline) }}{% if twitterRelatedAccounts %}&amp;related={{ twitterRelatedAccounts | join(',') }}{% endif %}&amp;via=FinancialTimes" rel="noopener"><i><span cass="o-header--visually-hidden"></span>Share on Twitter. Opens in a new window.</i></a>
         </li>
         <li class="o-share__action o-share__action--facebook">
-          <a href="http://www.facebook.com/sharer.php?u={{ url }}" rel="noopener"><i><span cass="o-header--visually-hidden"></span>Share on Facebook</i></a>
+          <a href="http://www.facebook.com/sharer.php?u={{ url }}" rel="noopener"><i><span cass="o-header--visually-hidden"></span>Share on Facebook. Opens in a new window.</i></a>
         </li>
         <li class="o-share__action o-share__action--linkedin">
-          <a href="https://www.linkedin.com/shareArticle?mini=true&amp;url={{ url }}&amp;source=Financial%20Times" rel="noopener"><i><span cass="o-header--visually-hidden"></span>Share on LinkedIn</i></a>
+          <a href="https://www.linkedin.com/shareArticle?mini=true&amp;url={{ url }}&amp;source=Financial%20Times" rel="noopener"><i><span cass="o-header--visually-hidden"></span>Share on LinkedIn. Opens in a new window.</i></a>
         </li>
         <li class="o-share__action o-share__action--whatsapp">
-          <a target="_blank" href="whatsapp://send?text={{ socialHeadline | default(headline) }}%20-%20{{ url }}" data-trackable="whatsapp" rel="noopener"><i><span cass="o-header--visually-hidden"></span>Share on Whatsapp</i></a>
+          <a target="_blank" href="whatsapp://send?text={{ socialHeadline | default(headline) }}%20-%20{{ url }}" data-trackable="whatsapp" rel="noopener"><i><span cass="o-header--visually-hidden"></span>Share on Whatsapp. Opens in a new window.</i></a>
         </li>
       </ul>
     </div>

--- a/views/includes/share.html
+++ b/views/includes/share.html
@@ -3,16 +3,16 @@
     <div data-o-component="o-share" class="o-share">
       <ul>
         <li class="o-share__action o-share__action--twitter">
-          <a href="https://twitter.com/intent/tweet?url={{ url }}&amp;text={{ tweetText | default(twitterHeadline) | default(socialHeadline) | default(headline) }}{% if twitterRelatedAccounts %}&amp;related={{ twitterRelatedAccounts | join(',') }}{% endif %}&amp;via=FinancialTimes" rel="noopener"><i><span cass="o-header--visually-hidden"></span>Share on Twitter. Opens in a new window.</i></a>
+          <a href="https://twitter.com/intent/tweet?url={{ url }}&amp;text={{ tweetText | default(twitterHeadline) | default(socialHeadline) | default(headline) }}{% if twitterRelatedAccounts %}&amp;related={{ twitterRelatedAccounts | join(',') }}{% endif %}&amp;via=FinancialTimes" rel="noopener"><i>Share on Twitter. Opens in a new window.</i></a>
         </li>
         <li class="o-share__action o-share__action--facebook">
-          <a href="http://www.facebook.com/sharer.php?u={{ url }}" rel="noopener"><i><span cass="o-header--visually-hidden"></span>Share on Facebook. Opens in a new window.</i></a>
+          <a href="http://www.facebook.com/sharer.php?u={{ url }}" rel="noopener"><i>Share on Facebook. Opens in a new window.</i></a>
         </li>
         <li class="o-share__action o-share__action--linkedin">
-          <a href="https://www.linkedin.com/shareArticle?mini=true&amp;url={{ url }}&amp;source=Financial%20Times" rel="noopener"><i><span cass="o-header--visually-hidden"></span>Share on LinkedIn. Opens in a new window.</i></a>
+          <a href="https://www.linkedin.com/shareArticle?mini=true&amp;url={{ url }}&amp;source=Financial%20Times" rel="noopener"><i>Share on LinkedIn. Opens in a new window.</i></a>
         </li>
         <li class="o-share__action o-share__action--whatsapp">
-          <a target="_blank" href="whatsapp://send?text={{ socialHeadline | default(headline) }}%20-%20{{ url }}" data-trackable="whatsapp" rel="noopener"><i><span cass="o-header--visually-hidden"></span>Share on Whatsapp. Opens in a new window.</i></a>
+          <a target="_blank" href="whatsapp://send?text={{ socialHeadline | default(headline) }}%20-%20{{ url }}" data-trackable="whatsapp" rel="noopener"><i>Share on Whatsapp. Opens in a new window.</i></a>
         </li>
       </ul>
     </div>

--- a/views/includes/share.html
+++ b/views/includes/share.html
@@ -3,16 +3,16 @@
     <div data-o-component="o-share" class="o-share">
       <ul>
         <li class="o-share__action o-share__action--twitter">
-          <a href="https://twitter.com/intent/tweet?url={{ url }}&amp;text={{ tweetText | default(twitterHeadline) | default(socialHeadline) | default(headline) }}{% if twitterRelatedAccounts %}&amp;related={{ twitterRelatedAccounts | join(',') }}{% endif %}&amp;via=FinancialTimes" rel="noopener"><i>Twitter</i></a>
+          <a href="https://twitter.com/intent/tweet?url={{ url }}&amp;text={{ tweetText | default(twitterHeadline) | default(socialHeadline) | default(headline) }}{% if twitterRelatedAccounts %}&amp;related={{ twitterRelatedAccounts | join(',') }}{% endif %}&amp;via=FinancialTimes" rel="noopener"><i><span cass="o-header--visually-hidden"></span>Share on Twitter</i></a>
         </li>
         <li class="o-share__action o-share__action--facebook">
-          <a href="http://www.facebook.com/sharer.php?u={{ url }}" rel="noopener"><i>Facebook</i></a>
+          <a href="http://www.facebook.com/sharer.php?u={{ url }}" rel="noopener"><i><span cass="o-header--visually-hidden"></span>Share on Facebook</i></a>
         </li>
         <li class="o-share__action o-share__action--linkedin">
-          <a href="https://www.linkedin.com/shareArticle?mini=true&amp;url={{ url }}&amp;source=Financial%20Times" rel="noopener"><i>LinkedIn</i></a>
+          <a href="https://www.linkedin.com/shareArticle?mini=true&amp;url={{ url }}&amp;source=Financial%20Times" rel="noopener"><i><span cass="o-header--visually-hidden"></span>Share on LinkedIn</i></a>
         </li>
         <li class="o-share__action o-share__action--whatsapp">
-          <a target="_blank" href="whatsapp://send?text={{ socialHeadline | default(headline) }}%20-%20{{ url }}" data-trackable="whatsapp" rel="noopener"><i>Whatsapp</i></a>
+          <a target="_blank" href="whatsapp://send?text={{ socialHeadline | default(headline) }}%20-%20{{ url }}" data-trackable="whatsapp" rel="noopener"><i><span cass="o-header--visually-hidden"></span>Share on Whatsapp</i></a>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
This project's in really good shape a11y-wise 👏 

I've only added some minor fixes:
- Removed `<H6>`s from the footer
- pa11y is no Ignoring ads as well as comments
- added context to social media links for screen readers, i.e. "Share on Twitter" rather than "Twitter"
- added "Opens in a new window" to `_blank` targets
- removed `#void` from copyright href and replaced with dummy url. Leaving `#void` in accidentally would cause a wcag violation 
- added `a11y:local` script to run a11y checks locally manually
- made npm a11y script names shorter for a better chance of us typing them locally 😬 
- removed warnings and notices from all pa11y output (left just errors)

One thing I would strongly suggest is removing the `--threshold` argument in 
https://github.com/ft-interactive/starter-kit/blob/master/package.json#L85-L86
but have left that to you, as these would mean the build fails if there's a single error, similar to the qa tests

This template currently passes pa11y and has 0 errors in [HTMLCodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/)
