### PR TITLE
Fix capitalisation error resulting in blank readme pages on new projects

### DIFF
--- a/configure
+++ b/configure
@@ -58,7 +58,7 @@ then
 fi
 echo "Setting URL to $URL"
 
-template_str=$(cat readme.md.template)
+TEMPLATE_STR=$(cat readme.md.template)
 
 if [ -n "$UUID" ]
 then


### PR DESCRIPTION
Error resulted in blank readme pages on new starter kit projects

Should hopefully fix #153 