### PR TITLE
Hackily fixes issue with o-ads

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.0.0",
-    "@financial-times/g-components": "^2.1.3",
+    "@financial-times/g-components": "^2.1.17",
     "prop-types": "^15.6.2",
     "react": "^16.4.1",
     "react-dom": "^16.4.1",

--- a/server/register.js
+++ b/server/register.js
@@ -9,3 +9,5 @@ global.location = {
 global.document.location = {
   href: 'ig.ft.com',
 };
+
+global.document.getElementsByTagName = () => [];


### PR DESCRIPTION
This monkey patches some of the globals that o-ads calls in a side-effect-y manner upon module instantiation (See financial-times/o-ads#169) and updates g-components to the latest version.