### PR TITLE
Fix setup script substitute error

### DIFF
--- a/config/article.js
+++ b/config/article.js
@@ -186,7 +186,7 @@ export default (environment = 'development') => {
 
   // This explicitly sets the comments URL to the link page
   if (!config.linkPageUrl) {
-    config.linkPageUrl = `https://www.ft.com/content/${config.id}`;
+    config.linkPageUrl = 'https://www.ft.com/content' + config.id;
   }
 
   return config;


### PR DESCRIPTION
The string interpolation clashes with the setup script which results in the following syntax error:
`config.linkPageUrl = ;`

