### PR TITLE
Adds es2019 to polyfill set

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -66,7 +66,7 @@
       <%= JSON.stringify({ sentryEndpoint: 'https://ddbd80489ff549538250bbe37fa52bbd@sentry.io/71130'}) %>
     </script>
     <% } %>
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=<%= htmlWebpackPlugin.options.context.polyfillFeatures %>"></script>
+    <script src="https://cdn.polyfill.io/v3/polyfill.min.js?features=<%= htmlWebpackPlugin.options.context.polyfillFeatures %>"></script>
 
     <script type="text/javascript">
       cutsTheMustard =

--- a/config/article.js
+++ b/config/article.js
@@ -127,6 +127,8 @@ export default (environment = 'development') => {
       */
       // product: '',
     },
+    
+    polyfillFeatures: ['default', 'fetch', 'es2019'],
 
     // If you include a data set, uncomment and fill out the following to
     // surface via Google.


### PR DESCRIPTION
Includes:

Array.prototype.flat
Array.prototype.flatMap
Object.fromEntries
String.prototype.trimEnd
String.prototype.trimStart
See: Financial-Times/ig-us-election-2020#116

Supersedes https://github.com/Financial-Times/g-components/pull/165.