### PR TITLE
Updates Storybook config to reflect Webpack

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,3 +1,4 @@
+const { dirname, resolve } = require('path');
 const { getVVCRoot } = require('../app/util/isVVCInstalled');
 const vvcRoot = getVVCRoot();
 
@@ -31,6 +32,15 @@ module.exports = {
         },
       ],
     });
+
+    config.resolve.alias = {
+      ...(config.resolve.alias || {}),
+        '@financial-times/g-components': resolve(
+          dirname(require.resolve('@financial-times/g-components/package.json')),
+          'src'
+        ),
+        '@financial-times/vvc': vvcRoot || '',
+    }
 
     return config;
   }

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -35,13 +35,13 @@ module.exports = {
 
     config.resolve.alias = {
       ...(config.resolve.alias || {}),
-        '@financial-times/g-components': resolve(
-          dirname(require.resolve('@financial-times/g-components/package.json')),
-          'src'
-        ),
-        '@financial-times/vvc': vvcRoot || '',
-    }
+      '@financial-times/g-components': resolve(
+        dirname(require.resolve('@financial-times/g-components/package.json')),
+        'src'
+      ),
+      '@financial-times/vvc': vvcRoot || '',
+    };
 
     return config;
-  }
+  },
 };


### PR DESCRIPTION
This allows g-components/vvc to be imported directly without having to add `src/` to the path.