### PR TITLE
Update selectors for headline and topic link in qa tests

### DIFF
--- a/test/qa/qa.spec.js
+++ b/test/qa/qa.spec.js
@@ -87,7 +87,7 @@ describe('QA tests', () => {
     });
 
     it('has a populated topic link', () => {
-      const topicLink = document.querySelector('.o-typography-topic');
+      const topicLink = document.querySelector('.o-editorial-typography-topic');
 
       should.exist(topicLink);
       topicLink.textContent.should.not.equal('');
@@ -95,7 +95,7 @@ describe('QA tests', () => {
     });
 
     it('has a populated headline', () => {
-      const headline = document.querySelector('h1.o-typography-headline');
+      const headline = document.querySelector('h1.o-editorial-layout-heading-1');
 
       should.exist(headline);
       headline.textContent.should.not.equal('');


### PR DESCRIPTION
We noticed on the US election that the qa tests were failing as the selectors for the topic link and the headline didn't match the selectors output by g-components. This PR updates the selectors to match those used by the topper components in g-components. 