### PR TITLE
Removes eslint-plugin-prettier, creates VSCode workspace config for unified settings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,7 @@
     "airbnb/hooks",
     "plugin:mdx/recommended",
     "plugin:prettier/recommended",
+    "prettier",
     "prettier/react"
   ],
   "root": true,

--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,6 @@
     "airbnb",
     "airbnb/hooks",
     "plugin:mdx/recommended",
-    "plugin:prettier/recommended",
     "prettier",
     "prettier/react"
   ],

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,3 @@ package-lock.json
 npm-debug.log*
 .env
 .DS_Store
-.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,25 +1,7 @@
 {
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "eslint.format.enable": true,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
-  },
-  "workbench.colorCustomizations": {
-    "activityBar.activeBackground": "#eead25",
-    "activityBar.activeBorder": "#097653",
-    "activityBar.background": "#eead25",
-    "activityBar.foreground": "#15202b",
-    "activityBar.inactiveForeground": "#15202b99",
-    "activityBarBadge.background": "#097653",
-    "activityBarBadge.foreground": "#e7e7e7",
-    "statusBar.background": "#d09210",
-    "statusBar.foreground": "#15202b",
-    "statusBarItem.hoverBackground": "#a1710c",
-    "titleBar.activeBackground": "#d09210",
-    "titleBar.activeForeground": "#15202b",
-    "titleBar.inactiveBackground": "#d0921099",
-    "titleBar.inactiveForeground": "#15202b99"
-  },
-  "peacock.color": "#d09210"
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,25 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "eslint.format.enable": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
+  "workbench.colorCustomizations": {
+    "activityBar.activeBackground": "#eead25",
+    "activityBar.activeBorder": "#097653",
+    "activityBar.background": "#eead25",
+    "activityBar.foreground": "#15202b",
+    "activityBar.inactiveForeground": "#15202b99",
+    "activityBarBadge.background": "#097653",
+    "activityBarBadge.foreground": "#e7e7e7",
+    "statusBar.background": "#d09210",
+    "statusBar.foreground": "#15202b",
+    "statusBarItem.hoverBackground": "#a1710c",
+    "titleBar.activeBackground": "#d09210",
+    "titleBar.activeForeground": "#15202b",
+    "titleBar.inactiveBackground": "#d0921099",
+    "titleBar.inactiveForeground": "#15202b99"
+  },
+  "peacock.color": "#d09210"
+}

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "eslint-plugin-import": "^2.20.0",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-mdx": "^1.6.5",
-    "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-react": "^7.17.0",
     "eslint-plugin-react-hooks": "^2.3.0",
     "extract-loader": "^2.0.1",


### PR DESCRIPTION
This will make it so that we use Prettier the same way everywhere, in line with [Prettier's guidance](https://prettier.io/docs/en/integrating-with-linters.html). Notes:

1. Eslint doesn't run Prettier anymore. Use your IDE's Prettier plugin instead now.
2. This will make Prettier-VSCode your default formatter. Please make sure you have [Prettier-VSCode](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) installed. The upside is it also formats HTML and other non-JS file types.
3. If you use [Peacock](https://marketplace.visualstudio.com/items?itemName=johnpapa.vscode-peacock), it will change the `.vscode/settings.json` file when you open VSCode. Please don't commit these changes when working on Starter Kit, though it's okay when working on spawned projects.