### PR TITLE
Use version 2.0 explicitly of CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.0
 jobs:
   build:
     working_directory: ~/project


### PR DESCRIPTION
Without using 2.0 explicitly, CircleCI now seems to be defaulting potentially to a newer version of the config, like 2.1? We got an odd error on Fan's new project, which said...
```
#!/bin/bash -eo pipefail
if [ ! -f "package.json" ]; then
  echo
  echo "---"
  echo "Unable to find your package.json file. Did you forget to set the app-dir parameter?"
  echo "---"
  echo
  echo "Current directory: $(pwd)"
  echo
  echo
  echo "List directory: "
  echo
  ls
  exit 1
fi
```
... and I think the `app-dir` parameter is new (maybe???)

Circle seems to like it much better when using `2.0` in the config, so hopefully this solves it for other things going forward.