### PR TITLE
Fix 'bad substitution' error in install script

### DIFF
--- a/config/article.js
+++ b/config/article.js
@@ -22,8 +22,8 @@ export default (environment = 'development') => {
 
     // summary === standfirst (Summary is what the content API calls it)
     summary:
-      'Ik kie neġi æpude pōsÞpriskribo, anċ ēg tiel subtegmenÞo.'
-      + 'Giga gārði esperǣntigo vi jes. Ċit plēj esceptīnte hu, ōl vola eksploðæ poǽ.',
+      'Ik kie neġi æpude pōsÞpriskribo, anċ ēg tiel subtegmenÞo.' +
+      'Giga gārði esperǣntigo vi jes. Ċit plēj esceptīnte hu, ōl vola eksploðæ poǽ.',
 
     topic: {
       name: 'Starter Kit',
@@ -46,7 +46,10 @@ export default (environment = 'development') => {
 
     // Byline can by a plain string, markdown, or array of authors
     // if array of authors, url is optional
-    bylines: [{ name: 'Author One' /* , url: '/foo/bar' // Must be absolute path */ }, { name: 'Author Two' }],
+    bylines: [
+      { name: 'Author One' /* , url: '/foo/bar' // Must be absolute path */ },
+      { name: 'Author Two' },
+    ],
 
     // Appears in the HTML <title>
     title: '',
@@ -183,7 +186,7 @@ export default (environment = 'development') => {
 
   // This explicitly sets the comments URL to the link page
   if (!config.linkPageUrl) {
-    config.linkPageUrl = `https://www.ft.com/content/${config.id}`;
+    config.linkPageUrl = 'https://www.ft.com/content/' + config.id;
   }
 
   return config;


### PR DESCRIPTION
Removes template string for linkPageUrl as this was causing errors in install script

You can test this by specifying the fix-setup-link-page-issue when running the install script