### PR TITLE
Updates CircleCI to consume Doppler secrets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,13 +14,13 @@ jobs:
       name: node/default
       tag: '16.13-browsers'
     steps:
+      - checkout
       - run:
-          name: Install Doppler CLI to current directory
+          name: Install Doppler CLI
           command: (curl -Ls https://cli.doppler.com/install.sh || wget -qO- https://cli.doppler.com/install.sh) | sh -s -- --no-install --no-package-manager
       - run:
           name: Install git-lfs
           command: curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash && sudo apt-get install git-lfs && git lfs install    
-      - checkout
       - run:
           name: Install dependencies
           command: npm install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,13 @@
 version: 2.1
+workflows:
+  starter-kit-s3-deployment:
+    jobs:
+      - build:
+          context:
+            - djd-starter-kit-s3-deployment # context is named the same in both orgs
 orbs:
   node: circleci/node@4.7.0
+  doppler: conpago/doppler@1.3.5
 jobs:
   build:
     working_directory: ~/project
@@ -8,6 +15,8 @@ jobs:
       name: node/default
       tag: '16.13-browsers'
     steps:
+      - doppler/install
+      - doppler/load_secrets
       - run:
           name: Install git-lfs
           command: curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash && sudo apt-get install git-lfs && git lfs install    

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,9 @@ jobs:
           command: |
             if [ "$PREVIEW" == "true" ]
             then
-              doppler run --command "npm run deploy -- --confirm --preview"
+              ./doppler run --command "npm run deploy -- --confirm --preview"
             else
-              doppler run --command "npm run deploy -- --confirm"
+              ./doppler run --command "npm run deploy -- --confirm"
             fi
       - run:
           name: Check accessibility of deployed site

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,6 @@ workflows:
             - djd-starter-kit-s3-deployment # context is named the same in both orgs
 orbs:
   node: circleci/node@4.7.0
-  doppler: conpago/doppler@1.3.5
 jobs:
   build:
     working_directory: ~/project
@@ -15,8 +14,9 @@ jobs:
       name: node/default
       tag: '16.13-browsers'
     steps:
-      - doppler/install
-      - doppler/load_secrets
+      - run:
+          name: Install Doppler CLI to current directory
+          command: (curl -Ls https://cli.doppler.com/install.sh || wget -qO- https://cli.doppler.com/install.sh) | sh -s -- --no-install --no-package-manager
       - run:
           name: Install git-lfs
           command: curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash && sudo apt-get install git-lfs && git lfs install    
@@ -35,9 +35,9 @@ jobs:
           command: |
             if [ "$PREVIEW" == "true" ]
             then
-              npm run deploy -- --confirm --preview
+              doppler run --command "npm run deploy -- --confirm --preview"
             else
-              npm run deploy -- --confirm
+              doppler run --command "npm run deploy -- --confirm"
             fi
       - run:
           name: Check accessibility of deployed site


### PR DESCRIPTION
The above adds to the CircleCI workflow two things:
* Consumes a context called `djd-starter-kit-s3-deploy` (this is created in both CircleCI orbs with the same environment variable, `DOPPLER_TOKEN`, that is able to access the `ci` environment in a Doppler project called `djd-starter-kit-s3-deploy` containing the AWS S3 deployment secrets needed by g-deploy)
* Installs the Doppler orb
* Uses the DOPPLER_TOKEN  env var from the CircleCI context to run `g-deploy` using Doppler secrets

…The idea is that we store the usual S3 deployment-related secrets in Doppler from here on out. This would totally obviate the need to ever do `buildbot reinit` and vastly simplify rotating secrets.