### PR TITLE
Update Pa11y to fix mapbox / threejs timeout issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "jsdom": "^11.11.0",
     "mini-css-extract-plugin": "^0.4.0",
     "mocha": "^8.1.3",
-    "pa11y": "^5.3.0",
+    "pa11y": "^6.2.3",
     "postcss-import": "^11.1.0",
     "postcss-loader": "^2.0.6",
     "postcss-preset-env": "^6.6.0",


### PR DESCRIPTION
We had a couple of starter kit projects where Pa11y was timing out due to Three.js / Mapbox elements. Even when those elements were added to hiddenElements and/or the timeout was increased, it was still timing out. Updating Pa11y seems to fix it.