### PR TITLE
React 18 Index Fix

### DIFF
--- a/app/index.jsx
+++ b/app/index.jsx
@@ -7,14 +7,10 @@
  */
 
 import React from 'react';
-import { hydrate, render } from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import App from './app';
 import './styles.scss';
 
-const rootElement = document.getElementById('root');
-
-if (rootElement.hasChildNodes()) {
-  hydrate(<App />, rootElement);
-} else {
-  render(<App />, rootElement);
-}
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(<App />);

--- a/package.json
+++ b/package.json
@@ -49,7 +49,9 @@
   "dependencies": {
     "@financial-times/g-components": "^9.0.1",
     "@financial-times/o-colors": "^6.6.0",
-    "@financial-times/o-grid": "^6.1.5"
+    "@financial-times/o-grid": "^6.1.5",
+    "react": "^18.1.0",
+    "react-dom": "^18.1.0"
   },
   "type": "module"
 }


### PR DESCRIPTION
Changing render in index.jsx to be compatible with react 18

Otherwise, you receive this warning:
`Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://reactjs.org/link/switch-to-createroot`