### PR TITLE
Add vs-components and update README

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,10 @@ jobs:
           command: (curl -Ls https://cli.doppler.com/install.sh || wget -qO- https://cli.doppler.com/install.sh) | sh -s -- --no-install --no-package-manager
       - run:
           name: Install dependencies
-          command: npm install
+          command: |
+            echo "@ft-interactive:registry=https://npm.pkg.github.com/" >> .npmrc
+            ./doppler run --command 'echo "//npm.pkg.github.com/:_authToken=$GPR_AUTH_TOKEN" >> .npmrc'
+            npm install
       - run:
           name: Build
           command: ./doppler run --command "npm run build"

--- a/README.md
+++ b/README.md
@@ -8,30 +8,7 @@ A template for IG projects — everything you need to build a standalone front e
 
 #### Getting started
 
-To start a new project based on Starter Kit, run this setup script in your terminal:
-
-```sh
-eval "$(curl -s https://raw.githubusercontent.com/ft-interactive/starter-kit/main/install)"
-```
-
-What the setup script does:
-
-- Asks you a few questions about your project (e.g. title, description).
-- Clones Starter Kit to your own computer (but reinitialises it as a brand new git repo with no history).
-- Runs `npm install` to grab all the dependencies (this takes a few minutes).
-- Runs `npm start` for the first time — now you can start coding.
-
-You can also re-initialise a Starter Kit project to use the latest version by providing a path
-to an existing project in the first step of the wizard. This will put everything in the folder into
-a new commit (_including_ things that aren't version controlled and aren't in .gitignore), wipe the
-folder, then add Starter Kit as a new commit. It doesn't try to upgrade your code at all, though
-you can generally restore everything by running the following afterwards:
-
-```bash
-git checkout HEAD~1 -- client config
-```
-
-This assumes your project keeps most of your data in the `app/` and `config/` folders.
+Select the green `Use this template` button at the top of the page to Create a new repository. Follow the steps as prompted to clone your repository locally. If it is your first time running a Starter Kit project follow the [setup instructions for vs-components](https://github.com/ft-interactive/vs-components#setup). Then run `npm install` in your terminal at the project root directory.
 
 #### Using the built in tasks
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
         "@financial-times/g-components": "^9.0.1",
         "@financial-times/o-colors": "^6.6.0",
         "@financial-times/o-grid": "^6.1.5",
-        "@ft-interactive/vs-components": "^1.0.0",
+        "@ft-interactive/vs-components": "^1.1.2",
         "react": "^18.1.0",
         "react-dom": "^18.1.0"
       },
@@ -344,6 +344,7 @@
       "version": "7.22.4",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.4.tgz",
       "integrity": "sha512-VLLsx06XkEYqBtE5YGPwfSGwfrjnyPP5oiGty3S8pQLFDFLaS8VwWSIxkTXpcvr5zeYLE6+MBNl2npl/YnfofA==",
+      "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -1760,9 +1761,9 @@
       }
     },
     "node_modules/@ft-interactive/vs-components": {
-      "version": "1.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@ft-interactive/vs-components/1.0.0/6b77e1f364c1b3459b609380b8aac289c9a3de9f",
-      "integrity": "sha512-FKbgvdHIRXLGX3Wb7K/aPOipvTe2Pxtjs7x6Yu+ykf7oojc+RssdoUjXzASK9ElZs04XdrBru9lq+xaq/40dPw==",
+      "version": "1.1.2",
+      "resolved": "https://npm.pkg.github.com/download/@ft-interactive/vs-components/1.1.2/7ea5819b795c118a044ac488a44ca28395ec8403",
+      "integrity": "sha512-UGaY4MIIfxEUYkxNXRFnTCC2ALw7E7gY5+9hhUrXOOyZXwZC8k2sXRIJ88xqV8t8DeR/aDxvOXsaIVcKThTXtg==",
       "license": "PROPRIETARY",
       "dependencies": {
         "@financial-times/g-components": "^9.0.1",
@@ -1770,7 +1771,6 @@
         "@financial-times/o-icons": "^7.7.0",
         "@financial-times/o-normalise": "^3.3.1",
         "classnames": "^2.3.1",
-        "g-components": "^1.0.0",
         "prop-types": "^15.7.2"
       },
       "peerDependencies": {
@@ -2246,24 +2246,6 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0"
-      }
-    },
-    "node_modules/@vue/compiler-sfc": {
-      "version": "2.7.14",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.14.tgz",
-      "integrity": "sha512-aNmNHyLPsw+sVvlQFQ2/8sjNuLtK54TC6cuKnVzAY93ks4ZBrvwQSnkkIh7bsbNhum5hJBS00wSDipQ937f5DA==",
-      "dependencies": {
-        "@babel/parser": "^7.18.4",
-        "postcss": "^8.4.14",
-        "source-map": "^0.6.1"
-      }
-    },
-    "node_modules/@vue/compiler-sfc/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/@welldone-software/why-did-you-render": {
@@ -5194,19 +5176,6 @@
       "integrity": "sha512-ROX5K8RSfCBDSpFDWPmu6bmRY9C+r/rwuDXR4nXUpBdbF1LGPHTsbw9Ds5XhVi8xTVHo+XiWydi2gCje+zepfA==",
       "optional": true
     },
-    "node_modules/g-components": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/g-components/-/g-components-1.0.0.tgz",
-      "integrity": "sha512-ep7I0PUY0ltGn0Ku1V2pMggEILUu+77K0H1V3FXCBRHjih/TY01uebRXLjU/VdT1RhavDmC8BECYlcisAUf1Uw==",
-      "dependencies": {
-        "vue": "^2.4.2",
-        "vue-router": "^2.7.0"
-      },
-      "engines": {
-        "node": ">= 4.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -7815,7 +7784,8 @@
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -7833,6 +7803,7 @@
       "version": "8.4.24",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
       "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7860,6 +7831,7 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
       "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9054,6 +9026,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9980,25 +9953,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/vue": {
-      "version": "2.7.14",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.14.tgz",
-      "integrity": "sha512-b2qkFyOM0kwqWFuQmgd4o+uHGU7T+2z3T+WQp8UBjADfEv2n4FEMffzBmCKNP0IGzOEEfYjvtcC62xaSKeQDrQ==",
-      "dependencies": {
-        "@vue/compiler-sfc": "2.7.14",
-        "csstype": "^3.1.0"
-      }
-    },
-    "node_modules/vue-router": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-2.8.1.tgz",
-      "integrity": "sha512-MC4jacHBhTPKtmcfzvaj2N7g6jgJ/Z/eIjZdt+yUaUOM1iKC0OUIlO/xCtz6OZFFTNUJs/1YNro2GN/lE+nOXA=="
-    },
-    "node_modules/vue/node_modules/csstype": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
-    },
     "node_modules/w3c-xmlserializer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
@@ -10615,7 +10569,8 @@
     "@babel/parser": {
       "version": "7.22.4",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.4.tgz",
-      "integrity": "sha512-VLLsx06XkEYqBtE5YGPwfSGwfrjnyPP5oiGty3S8pQLFDFLaS8VwWSIxkTXpcvr5zeYLE6+MBNl2npl/YnfofA=="
+      "integrity": "sha512-VLLsx06XkEYqBtE5YGPwfSGwfrjnyPP5oiGty3S8pQLFDFLaS8VwWSIxkTXpcvr5zeYLE6+MBNl2npl/YnfofA==",
+      "dev": true
     },
     "@babel/plugin-syntax-jsx": {
       "version": "7.21.4",
@@ -11624,16 +11579,15 @@
       }
     },
     "@ft-interactive/vs-components": {
-      "version": "1.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@ft-interactive/vs-components/1.0.0/6b77e1f364c1b3459b609380b8aac289c9a3de9f",
-      "integrity": "sha512-FKbgvdHIRXLGX3Wb7K/aPOipvTe2Pxtjs7x6Yu+ykf7oojc+RssdoUjXzASK9ElZs04XdrBru9lq+xaq/40dPw==",
+      "version": "1.1.2",
+      "resolved": "https://npm.pkg.github.com/download/@ft-interactive/vs-components/1.1.2/7ea5819b795c118a044ac488a44ca28395ec8403",
+      "integrity": "sha512-UGaY4MIIfxEUYkxNXRFnTCC2ALw7E7gY5+9hhUrXOOyZXwZC8k2sXRIJ88xqV8t8DeR/aDxvOXsaIVcKThTXtg==",
       "requires": {
         "@financial-times/g-components": "^9.0.1",
         "@financial-times/o-grid": "^6.1.7",
         "@financial-times/o-icons": "^7.7.0",
         "@financial-times/o-normalise": "^3.3.1",
         "classnames": "^2.3.1",
-        "g-components": "^1.0.0",
         "prop-types": "^15.7.2"
       }
     },
@@ -12055,23 +12009,6 @@
         "@babel/plugin-transform-react-jsx-self": "^7.21.0",
         "@babel/plugin-transform-react-jsx-source": "^7.19.6",
         "react-refresh": "^0.14.0"
-      }
-    },
-    "@vue/compiler-sfc": {
-      "version": "2.7.14",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.14.tgz",
-      "integrity": "sha512-aNmNHyLPsw+sVvlQFQ2/8sjNuLtK54TC6cuKnVzAY93ks4ZBrvwQSnkkIh7bsbNhum5hJBS00wSDipQ937f5DA==",
-      "requires": {
-        "@babel/parser": "^7.18.4",
-        "postcss": "^8.4.14",
-        "source-map": "^0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        }
       }
     },
     "@welldone-software/why-did-you-render": {
@@ -14400,15 +14337,6 @@
       "integrity": "sha512-ROX5K8RSfCBDSpFDWPmu6bmRY9C+r/rwuDXR4nXUpBdbF1LGPHTsbw9Ds5XhVi8xTVHo+XiWydi2gCje+zepfA==",
       "optional": true
     },
-    "g-components": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/g-components/-/g-components-1.0.0.tgz",
-      "integrity": "sha512-ep7I0PUY0ltGn0Ku1V2pMggEILUu+77K0H1V3FXCBRHjih/TY01uebRXLjU/VdT1RhavDmC8BECYlcisAUf1Uw==",
-      "requires": {
-        "vue": "^2.4.2",
-        "vue-router": "^2.7.0"
-      }
-    },
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -16338,7 +16266,8 @@
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
     },
     "picomatch": {
       "version": "2.3.1",
@@ -16350,6 +16279,7 @@
       "version": "8.4.24",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
       "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
+      "dev": true,
       "requires": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -16359,7 +16289,8 @@
         "nanoid": {
           "version": "3.3.6",
           "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-          "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
+          "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+          "dev": true
         }
       }
     },
@@ -17281,7 +17212,8 @@
     "source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true
     },
     "sourcemapped-stacktrace-node": {
       "version": "2.1.8",
@@ -17961,27 +17893,6 @@
           }
         }
       }
-    },
-    "vue": {
-      "version": "2.7.14",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.14.tgz",
-      "integrity": "sha512-b2qkFyOM0kwqWFuQmgd4o+uHGU7T+2z3T+WQp8UBjADfEv2n4FEMffzBmCKNP0IGzOEEfYjvtcC62xaSKeQDrQ==",
-      "requires": {
-        "@vue/compiler-sfc": "2.7.14",
-        "csstype": "^3.1.0"
-      },
-      "dependencies": {
-        "csstype": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-          "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
-        }
-      }
-    },
-    "vue-router": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-2.8.1.tgz",
-      "integrity": "sha512-MC4jacHBhTPKtmcfzvaj2N7g6jgJ/Z/eIjZdt+yUaUOM1iKC0OUIlO/xCtz6OZFFTNUJs/1YNro2GN/lE+nOXA=="
     },
     "w3c-xmlserializer": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
         "@financial-times/g-components": "^9.0.1",
         "@financial-times/o-colors": "^6.6.0",
         "@financial-times/o-grid": "^6.1.5",
+        "@ft-interactive/vs-components": "^1.0.0",
         "react": "^18.1.0",
         "react-dom": "^18.1.0"
       },
@@ -343,7 +344,6 @@
       "version": "7.22.4",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.4.tgz",
       "integrity": "sha512-VLLsx06XkEYqBtE5YGPwfSGwfrjnyPP5oiGty3S8pQLFDFLaS8VwWSIxkTXpcvr5zeYLE6+MBNl2npl/YnfofA==",
-      "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -806,12 +806,6 @@
         "npm": "^7 || ^8"
       }
     },
-    "node_modules/@financial-times/fticons": {
-      "version": "1.23.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/fticons/-/fticons-1.23.1.tgz",
-      "integrity": "sha512-pBcOFpblNAUVl38Vez+WHpYlRC/gYkk30ANFiDWN7tUjKFsa2AbEMSJ2JBZsGEMvupPMBWKA/zsVqb29FmGnxA==",
-      "peer": true
-    },
     "node_modules/@financial-times/g-components": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/@financial-times/g-components/-/g-components-9.0.1.tgz",
@@ -1179,9 +1173,9 @@
       }
     },
     "node_modules/@financial-times/o-grid": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-grid/-/o-grid-6.1.5.tgz",
-      "integrity": "sha512-wjotgIlrkx0YvR96MD6FwB0tKuX4NyDiiz8FXlBGhsB/Csn1qDecsDQuhQ8XesBdbJI1LG1zrnOGrP/WQncCqg==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-grid/-/o-grid-6.1.7.tgz",
+      "integrity": "sha512-DzzPGELo1/2cxcc7gY8AI/2WArkKaQD3mn0epiYfZpgtyz6Tk4HXKbeJAsCp+vbZ5aKW7Cv0u9KGMQTXljzYUA==",
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -1212,14 +1206,11 @@
       }
     },
     "node_modules/@financial-times/o-icons": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-icons/-/o-icons-7.3.0.tgz",
-      "integrity": "sha512-JXrv87DW4gQtXw880wFSfnFpeOoBlB7AddSQPN1jUIU03058CEKCGST9ZSdbvgDq1bHrcGH9geSrifczhAf8kw==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-icons/-/o-icons-7.7.0.tgz",
+      "integrity": "sha512-6peB03pHRpBBn0F2TEHap6dkWO8Ovq4nytS3mNIBDtLEZWBYU97RESpIlq1aARZ7RIxZek2uEtT1oRaSfFv8zw==",
       "engines": {
         "npm": "^7 || ^8"
-      },
-      "peerDependencies": {
-        "@financial-times/fticons": "^1.23.1"
       }
     },
     "node_modules/@financial-times/o-labels": {
@@ -1768,6 +1759,25 @@
         "object-assign": "^4.1.1"
       }
     },
+    "node_modules/@ft-interactive/vs-components": {
+      "version": "1.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@ft-interactive/vs-components/1.0.0/6b77e1f364c1b3459b609380b8aac289c9a3de9f",
+      "integrity": "sha512-FKbgvdHIRXLGX3Wb7K/aPOipvTe2Pxtjs7x6Yu+ykf7oojc+RssdoUjXzASK9ElZs04XdrBru9lq+xaq/40dPw==",
+      "license": "PROPRIETARY",
+      "dependencies": {
+        "@financial-times/g-components": "^9.0.1",
+        "@financial-times/o-grid": "^6.1.7",
+        "@financial-times/o-icons": "^7.7.0",
+        "@financial-times/o-normalise": "^3.3.1",
+        "classnames": "^2.3.1",
+        "g-components": "^1.0.0",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
@@ -2236,6 +2246,24 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "2.7.14",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.14.tgz",
+      "integrity": "sha512-aNmNHyLPsw+sVvlQFQ2/8sjNuLtK54TC6cuKnVzAY93ks4ZBrvwQSnkkIh7bsbNhum5hJBS00wSDipQ937f5DA==",
+      "dependencies": {
+        "@babel/parser": "^7.18.4",
+        "postcss": "^8.4.14",
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/@welldone-software/why-did-you-render": {
@@ -5166,6 +5194,19 @@
       "integrity": "sha512-ROX5K8RSfCBDSpFDWPmu6bmRY9C+r/rwuDXR4nXUpBdbF1LGPHTsbw9Ds5XhVi8xTVHo+XiWydi2gCje+zepfA==",
       "optional": true
     },
+    "node_modules/g-components": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/g-components/-/g-components-1.0.0.tgz",
+      "integrity": "sha512-ep7I0PUY0ltGn0Ku1V2pMggEILUu+77K0H1V3FXCBRHjih/TY01uebRXLjU/VdT1RhavDmC8BECYlcisAUf1Uw==",
+      "dependencies": {
+        "vue": "^2.4.2",
+        "vue-router": "^2.7.0"
+      },
+      "engines": {
+        "node": ">= 4.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -7774,8 +7815,7 @@
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -7793,7 +7833,6 @@
       "version": "8.4.24",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
       "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7821,7 +7860,6 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
       "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9016,7 +9054,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9943,6 +9980,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/vue": {
+      "version": "2.7.14",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.14.tgz",
+      "integrity": "sha512-b2qkFyOM0kwqWFuQmgd4o+uHGU7T+2z3T+WQp8UBjADfEv2n4FEMffzBmCKNP0IGzOEEfYjvtcC62xaSKeQDrQ==",
+      "dependencies": {
+        "@vue/compiler-sfc": "2.7.14",
+        "csstype": "^3.1.0"
+      }
+    },
+    "node_modules/vue-router": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-2.8.1.tgz",
+      "integrity": "sha512-MC4jacHBhTPKtmcfzvaj2N7g6jgJ/Z/eIjZdt+yUaUOM1iKC0OUIlO/xCtz6OZFFTNUJs/1YNro2GN/lE+nOXA=="
+    },
+    "node_modules/vue/node_modules/csstype": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+    },
     "node_modules/w3c-xmlserializer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
@@ -10559,8 +10615,7 @@
     "@babel/parser": {
       "version": "7.22.4",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.4.tgz",
-      "integrity": "sha512-VLLsx06XkEYqBtE5YGPwfSGwfrjnyPP5oiGty3S8pQLFDFLaS8VwWSIxkTXpcvr5zeYLE6+MBNl2npl/YnfofA==",
-      "dev": true
+      "integrity": "sha512-VLLsx06XkEYqBtE5YGPwfSGwfrjnyPP5oiGty3S8pQLFDFLaS8VwWSIxkTXpcvr5zeYLE6+MBNl2npl/YnfofA=="
     },
     "@babel/plugin-syntax-jsx": {
       "version": "7.21.4",
@@ -10928,12 +10983,6 @@
       "resolved": "https://registry.npmjs.org/@financial-times/ft-date-format/-/ft-date-format-2.1.0.tgz",
       "integrity": "sha512-nVDEVgQTHU5vBQVC1zNb7erXDvOsugcPfTsm2L+nB0dSeIsGjKy+FMEUYpd05PQsw4c5H/IvownQuGLHhwolbw=="
     },
-    "@financial-times/fticons": {
-      "version": "1.23.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/fticons/-/fticons-1.23.1.tgz",
-      "integrity": "sha512-pBcOFpblNAUVl38Vez+WHpYlRC/gYkk30ANFiDWN7tUjKFsa2AbEMSJ2JBZsGEMvupPMBWKA/zsVqb29FmGnxA==",
-      "peer": true
-    },
     "@financial-times/g-components": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/@financial-times/g-components/-/g-components-9.0.1.tgz",
@@ -11168,9 +11217,9 @@
       }
     },
     "@financial-times/o-grid": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-grid/-/o-grid-6.1.5.tgz",
-      "integrity": "sha512-wjotgIlrkx0YvR96MD6FwB0tKuX4NyDiiz8FXlBGhsB/Csn1qDecsDQuhQ8XesBdbJI1LG1zrnOGrP/WQncCqg==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-grid/-/o-grid-6.1.7.tgz",
+      "integrity": "sha512-DzzPGELo1/2cxcc7gY8AI/2WArkKaQD3mn0epiYfZpgtyz6Tk4HXKbeJAsCp+vbZ5aKW7Cv0u9KGMQTXljzYUA==",
       "requires": {}
     },
     "@financial-times/o-header": {
@@ -11180,10 +11229,9 @@
       "requires": {}
     },
     "@financial-times/o-icons": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-icons/-/o-icons-7.3.0.tgz",
-      "integrity": "sha512-JXrv87DW4gQtXw880wFSfnFpeOoBlB7AddSQPN1jUIU03058CEKCGST9ZSdbvgDq1bHrcGH9geSrifczhAf8kw==",
-      "requires": {}
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-icons/-/o-icons-7.7.0.tgz",
+      "integrity": "sha512-6peB03pHRpBBn0F2TEHap6dkWO8Ovq4nytS3mNIBDtLEZWBYU97RESpIlq1aARZ7RIxZek2uEtT1oRaSfFv8zw=="
     },
     "@financial-times/o-labels": {
       "version": "6.2.2",
@@ -11573,6 +11621,20 @@
             "object-assign": "^4.1.1"
           }
         }
+      }
+    },
+    "@ft-interactive/vs-components": {
+      "version": "1.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@ft-interactive/vs-components/1.0.0/6b77e1f364c1b3459b609380b8aac289c9a3de9f",
+      "integrity": "sha512-FKbgvdHIRXLGX3Wb7K/aPOipvTe2Pxtjs7x6Yu+ykf7oojc+RssdoUjXzASK9ElZs04XdrBru9lq+xaq/40dPw==",
+      "requires": {
+        "@financial-times/g-components": "^9.0.1",
+        "@financial-times/o-grid": "^6.1.7",
+        "@financial-times/o-icons": "^7.7.0",
+        "@financial-times/o-normalise": "^3.3.1",
+        "classnames": "^2.3.1",
+        "g-components": "^1.0.0",
+        "prop-types": "^15.7.2"
       }
     },
     "@humanwhocodes/config-array": {
@@ -11993,6 +12055,23 @@
         "@babel/plugin-transform-react-jsx-self": "^7.21.0",
         "@babel/plugin-transform-react-jsx-source": "^7.19.6",
         "react-refresh": "^0.14.0"
+      }
+    },
+    "@vue/compiler-sfc": {
+      "version": "2.7.14",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.14.tgz",
+      "integrity": "sha512-aNmNHyLPsw+sVvlQFQ2/8sjNuLtK54TC6cuKnVzAY93ks4ZBrvwQSnkkIh7bsbNhum5hJBS00wSDipQ937f5DA==",
+      "requires": {
+        "@babel/parser": "^7.18.4",
+        "postcss": "^8.4.14",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
       }
     },
     "@welldone-software/why-did-you-render": {
@@ -14321,6 +14400,15 @@
       "integrity": "sha512-ROX5K8RSfCBDSpFDWPmu6bmRY9C+r/rwuDXR4nXUpBdbF1LGPHTsbw9Ds5XhVi8xTVHo+XiWydi2gCje+zepfA==",
       "optional": true
     },
+    "g-components": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/g-components/-/g-components-1.0.0.tgz",
+      "integrity": "sha512-ep7I0PUY0ltGn0Ku1V2pMggEILUu+77K0H1V3FXCBRHjih/TY01uebRXLjU/VdT1RhavDmC8BECYlcisAUf1Uw==",
+      "requires": {
+        "vue": "^2.4.2",
+        "vue-router": "^2.7.0"
+      }
+    },
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -16250,8 +16338,7 @@
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "picomatch": {
       "version": "2.3.1",
@@ -16263,7 +16350,6 @@
       "version": "8.4.24",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
       "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
-      "dev": true,
       "requires": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -16273,8 +16359,7 @@
         "nanoid": {
           "version": "3.3.6",
           "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-          "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
-          "dev": true
+          "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
         }
       }
     },
@@ -17196,8 +17281,7 @@
     "source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "dev": true
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
     },
     "sourcemapped-stacktrace-node": {
       "version": "2.1.8",
@@ -17877,6 +17961,27 @@
           }
         }
       }
+    },
+    "vue": {
+      "version": "2.7.14",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.14.tgz",
+      "integrity": "sha512-b2qkFyOM0kwqWFuQmgd4o+uHGU7T+2z3T+WQp8UBjADfEv2n4FEMffzBmCKNP0IGzOEEfYjvtcC62xaSKeQDrQ==",
+      "requires": {
+        "@vue/compiler-sfc": "2.7.14",
+        "csstype": "^3.1.0"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+          "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+        }
+      }
+    },
+    "vue-router": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-2.8.1.tgz",
+      "integrity": "sha512-MC4jacHBhTPKtmcfzvaj2N7g6jgJ/Z/eIjZdt+yUaUOM1iKC0OUIlO/xCtz6OZFFTNUJs/1YNro2GN/lE+nOXA=="
     },
     "w3c-xmlserializer": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@financial-times/g-components": "^9.0.1",
     "@financial-times/o-colors": "^6.6.0",
     "@financial-times/o-grid": "^6.1.5",
-    "@ft-interactive/vs-components": "^1.0.0",
+    "@ft-interactive/vs-components": "^1.1.1",
     "react": "^18.1.0",
     "react-dom": "^18.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@financial-times/g-components": "^9.0.1",
     "@financial-times/o-colors": "^6.6.0",
     "@financial-times/o-grid": "^6.1.5",
+    "@ft-interactive/vs-components": "^1.0.0",
     "react": "^18.1.0",
     "react-dom": "^18.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@financial-times/g-components": "^9.0.1",
     "@financial-times/o-colors": "^6.6.0",
     "@financial-times/o-grid": "^6.1.5",
-    "@ft-interactive/vs-components": "^1.1.1",
+    "@ft-interactive/vs-components": "^1.1.2",
     "react": "^18.1.0",
     "react-dom": "^18.1.0"
   },


### PR DESCRIPTION
- Adds [vs-components](https://github.com/ft-interactive/vs-components) as a dependency to starter-kit. We expect vs-components to contain components used in all starter-kit projects so it should be included by default.
- Updates README to remove installation script (as it's been deleted) and to include setup details required as a one off task for vs-components (create an .npmrc file in your home directory).