### PR TITLE
Add credits

### DIFF
--- a/app/app.jsx
+++ b/app/app.jsx
@@ -48,13 +48,10 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import {
-  ArticleLayout as Layout,
-  StoryTopper,
-  Epilogue,
-  Grid,
-} from '@financial-times/g-components';
+import { ArticleLayout as Layout, StoryTopper, Grid } from '@financial-times/g-components';
 import '@financial-times/g-components/styles.css';
+import Credits from '@ft-interactive/vs-components/Credits';
+import '@ft-interactive/vs-components/styles.css';
 
 const { GridChild, GridRow, GridContainer } = Grid;
 
@@ -144,11 +141,19 @@ const App = () => {
                       prǽantæŭlǽsÞa ǣs plue, tǣgō tiūdirekten ni neā.
                     </p>
                   </div>
+                  <Credits
+                    share={{
+                      url: context.url,
+                      socialHeadline: context.socialHeadline || context.headline,
+                      tweetText: context.tweetText || context.twitterHeadline,
+                      facebookHeadline: context.facebookHeadline,
+                    }}
+                    dark={context.flags.dark}
+                  />
                 </GridChild>
               </GridRow>
             </GridContainer>
           </div>
-          <Epilogue />
         </article>
       </main>
     </Layout>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
         "@financial-times/g-components": "^9.0.1",
         "@financial-times/o-colors": "^6.6.0",
         "@financial-times/o-grid": "^6.1.5",
-        "@ft-interactive/vs-components": "^1.1.2",
+        "@ft-interactive/vs-components": "^1.2.1",
         "react": "^18.1.0",
         "react-dom": "^18.1.0"
       },
@@ -790,6 +790,14 @@
         "@financial-times/o-viewport": "^5.1.1"
       }
     },
+    "node_modules/@financial-times/ads-personalised-consent": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@financial-times/ads-personalised-consent/-/ads-personalised-consent-5.2.8.tgz",
+      "integrity": "sha512-LlAF8WShhWQamI9Xsk1ChxeF2YzmiCWBa01t3JBpupar+V96WbbpSV5Xsx5lrsbcRdu+EtOuR4zlujBU0niR4A==",
+      "dependencies": {
+        "@financial-times/privacy-legislation-client": "^1.0.0"
+      }
+    },
     "node_modules/@financial-times/flourish-receive-custom-analytics": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@financial-times/flourish-receive-custom-analytics/-/flourish-receive-custom-analytics-1.2.1.tgz",
@@ -809,16 +817,16 @@
       }
     },
     "node_modules/@financial-times/g-components": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/g-components/-/g-components-9.0.1.tgz",
-      "integrity": "sha512-c9Zo4xIIbyvtXUJ/dT1zqMqdmjBQwT1WTqmT6KcVvOqwhHPBqoJnaE2gtFYjG+df/+sthOEahVS3wEmbcnQ45w==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@financial-times/g-components/-/g-components-9.0.3.tgz",
+      "integrity": "sha512-hTkGx8wVy1T2yUZwl3WNInQN8bkJu8Lgn96qaqxrPd54j25WVu3GD2kalRpBaD2TVHcUh0b8rLuUYIAM+eNaYA==",
       "dependencies": {
         "@financial-times/ads-legacy-o-ads": "5.2.2",
         "@financial-times/flourish-receive-custom-analytics": "^1.2.0",
         "@financial-times/format-number": "^1.0.0",
         "@financial-times/ft-date-format": "^2.1.0",
         "@financial-times/math": "^1.1.0",
-        "@financial-times/n-tracking": "^5.1.0",
+        "@financial-times/n-tracking": "^7.2.1",
         "@financial-times/o-brand": "^4.2.1",
         "@financial-times/o-buttons": "^7.5.0",
         "@financial-times/o-colors": "^6.4.2",
@@ -985,19 +993,21 @@
       }
     },
     "node_modules/@financial-times/n-tracking": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-tracking/-/n-tracking-5.2.0.tgz",
-      "integrity": "sha512-oGeIoHRUE3f6Ng3g6KsM6qZuSJPuFvmKd/XHsySIMOKjAc9go8ZCZBceCqBeo2e0OzFu12qNWgZ1JKOirJ3EbQ==",
-      "hasInstallScript": true,
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-tracking/-/n-tracking-7.2.2.tgz",
+      "integrity": "sha512-WG9wvYizNicF047UbQXmTOA/XxBSU7sIv6bPjKwTxoy7er7biSC/btq15zIuW80i8Rh2a5WF98QMJYzTwWU/GA==",
       "dependencies": {
+        "@financial-times/ads-personalised-consent": "^5.2.8",
         "@financial-times/o-grid": "^5.0.0",
-        "@financial-times/o-tracking": "^4.0.0",
+        "@financial-times/o-tracking": "^4.5.0",
         "@financial-times/o-viewport": "^4.0.0",
-        "ready-state": "^2.0.5"
+        "@financial-times/privacy-us-privacy": "^2.1.0",
+        "ready-state": "^2.0.5",
+        "web-vitals": "^3.4.0"
       },
       "engines": {
-        "node": "14.x || 16.x",
-        "npm": "7.x || 8.x"
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
         "react": ">=16.9.0 <19.0.0"
@@ -1388,14 +1398,14 @@
       }
     },
     "node_modules/@financial-times/o-tracking": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-tracking/-/o-tracking-4.3.2.tgz",
-      "integrity": "sha512-lgrSbAyrQjpX6Zs2K+TtbGhCc2WcvxYR1y6zA2wsR+EY3Ohh8nxrQQQYjoprO0ZDskfS+GF4DtG2rwc2l+2llw==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-tracking/-/o-tracking-4.5.1.tgz",
+      "integrity": "sha512-CwUT4OyHIjR/cXFQR3EGyLiO6HCb26W7AAYgzr+40QUlutw9FJ4Y/RBKVW9+XBkcni4IWhdXKU5mD0Mm+wW7oA==",
       "dependencies": {
         "ftdomdelegate": "^5"
       },
       "engines": {
-        "npm": "^7 || ^8"
+        "npm": ">7"
       }
     },
     "node_modules/@financial-times/o-typography": {
@@ -1455,6 +1465,24 @@
       "dependencies": {
         "remove-accents": "^0.4.2"
       }
+    },
+    "node_modules/@financial-times/privacy-legislation-client": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/privacy-legislation-client/-/privacy-legislation-client-1.3.0.tgz",
+      "integrity": "sha512-S32eO94SosciyBzYehxoH7Tg45pO5Jz9KGwqUxVnAUrZuS4UzuKNmPVPKrRzQxbLbyaKbGtYbp9qf5RSf9SiXA=="
+    },
+    "node_modules/@financial-times/privacy-us-privacy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/privacy-us-privacy/-/privacy-us-privacy-2.1.0.tgz",
+      "integrity": "sha512-l83sj1y9GfYZRrDAUk4P7HqBPffhL8oYrbEuSG+V7EFa4LTYKcy1/6ju1VGbzclbLhPeBUePB1bQ2G7BpvUPhQ==",
+      "dependencies": {
+        "@financial-times/privacy-legislation-client": "^2.1.0"
+      }
+    },
+    "node_modules/@financial-times/privacy-us-privacy/node_modules/@financial-times/privacy-legislation-client": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/privacy-legislation-client/-/privacy-legislation-client-2.1.0.tgz",
+      "integrity": "sha512-NU7eh19nJ2CJJuF4qyTfbK82KXn5TBSS5uNiABaioYa7G8ey5mqfXT8oQid3GX9Dx4P7rhWqw3C3jFTsBf3Lig=="
     },
     "node_modules/@financial-times/sass-mq": {
       "version": "5.2.3",
@@ -1762,12 +1790,12 @@
       }
     },
     "node_modules/@ft-interactive/vs-components": {
-      "version": "1.1.2",
-      "resolved": "https://npm.pkg.github.com/download/@ft-interactive/vs-components/1.1.2/7ea5819b795c118a044ac488a44ca28395ec8403",
-      "integrity": "sha512-UGaY4MIIfxEUYkxNXRFnTCC2ALw7E7gY5+9hhUrXOOyZXwZC8k2sXRIJ88xqV8t8DeR/aDxvOXsaIVcKThTXtg==",
+      "version": "1.2.1",
+      "resolved": "https://npm.pkg.github.com/download/@ft-interactive/vs-components/1.2.1/f3f3ea930113b466f2e60634f1c120f49f917246",
+      "integrity": "sha512-qyx2iUfnOwBqUViBePgd6fsBxqCd3Dzn9YYjeQRxfPtZfg25V6ndmolr1m3naKVnRPHtqqigS4LUCFZ+82VY7Q==",
       "license": "PROPRIETARY",
       "dependencies": {
-        "@financial-times/g-components": "^9.0.1",
+        "@financial-times/g-components": "^9.0.3",
         "@financial-times/o-grid": "^6.1.7",
         "@financial-times/o-icons": "^7.7.0",
         "@financial-times/o-normalise": "^3.3.1",
@@ -9995,6 +10023,11 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/web-vitals": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.5.0.tgz",
+      "integrity": "sha512-f5YnCHVG9Y6uLCePD4tY8bO/Ge15NPEQWtvm3tPzDKygloiqtb4SVqRHBcrIAqo2ztqX5XueqDn97zHF0LdT6w=="
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -10936,6 +10969,14 @@
         "@financial-times/o-viewport": "^5.1.1"
       }
     },
+    "@financial-times/ads-personalised-consent": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@financial-times/ads-personalised-consent/-/ads-personalised-consent-5.2.8.tgz",
+      "integrity": "sha512-LlAF8WShhWQamI9Xsk1ChxeF2YzmiCWBa01t3JBpupar+V96WbbpSV5Xsx5lrsbcRdu+EtOuR4zlujBU0niR4A==",
+      "requires": {
+        "@financial-times/privacy-legislation-client": "^1.0.0"
+      }
+    },
     "@financial-times/flourish-receive-custom-analytics": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@financial-times/flourish-receive-custom-analytics/-/flourish-receive-custom-analytics-1.2.1.tgz",
@@ -10952,16 +10993,16 @@
       "integrity": "sha512-nVDEVgQTHU5vBQVC1zNb7erXDvOsugcPfTsm2L+nB0dSeIsGjKy+FMEUYpd05PQsw4c5H/IvownQuGLHhwolbw=="
     },
     "@financial-times/g-components": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/g-components/-/g-components-9.0.1.tgz",
-      "integrity": "sha512-c9Zo4xIIbyvtXUJ/dT1zqMqdmjBQwT1WTqmT6KcVvOqwhHPBqoJnaE2gtFYjG+df/+sthOEahVS3wEmbcnQ45w==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@financial-times/g-components/-/g-components-9.0.3.tgz",
+      "integrity": "sha512-hTkGx8wVy1T2yUZwl3WNInQN8bkJu8Lgn96qaqxrPd54j25WVu3GD2kalRpBaD2TVHcUh0b8rLuUYIAM+eNaYA==",
       "requires": {
         "@financial-times/ads-legacy-o-ads": "5.2.2",
         "@financial-times/flourish-receive-custom-analytics": "^1.2.0",
         "@financial-times/format-number": "^1.0.0",
         "@financial-times/ft-date-format": "^2.1.0",
         "@financial-times/math": "^1.1.0",
-        "@financial-times/n-tracking": "^5.1.0",
+        "@financial-times/n-tracking": "^7.2.1",
         "@financial-times/o-brand": "^4.2.1",
         "@financial-times/o-buttons": "^7.5.0",
         "@financial-times/o-colors": "^6.4.2",
@@ -11087,14 +11128,17 @@
       "requires": {}
     },
     "@financial-times/n-tracking": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-tracking/-/n-tracking-5.2.0.tgz",
-      "integrity": "sha512-oGeIoHRUE3f6Ng3g6KsM6qZuSJPuFvmKd/XHsySIMOKjAc9go8ZCZBceCqBeo2e0OzFu12qNWgZ1JKOirJ3EbQ==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-tracking/-/n-tracking-7.2.2.tgz",
+      "integrity": "sha512-WG9wvYizNicF047UbQXmTOA/XxBSU7sIv6bPjKwTxoy7er7biSC/btq15zIuW80i8Rh2a5WF98QMJYzTwWU/GA==",
       "requires": {
+        "@financial-times/ads-personalised-consent": "^5.2.8",
         "@financial-times/o-grid": "^5.0.0",
-        "@financial-times/o-tracking": "^4.0.0",
+        "@financial-times/o-tracking": "^4.5.0",
         "@financial-times/o-viewport": "^4.0.0",
-        "ready-state": "^2.0.5"
+        "@financial-times/privacy-us-privacy": "^2.1.0",
+        "ready-state": "^2.0.5",
+        "web-vitals": "^3.4.0"
       },
       "dependencies": {
         "@financial-times/o-grid": {
@@ -11291,9 +11335,9 @@
       "integrity": "sha512-msWiGjGATDklDyRTMNPSiku1JTb3nMxHieHyMBFPSOfwYJXKaxugcOwPv+bfnMn/wMxbU8TjCa/EUSZZCfTOWg=="
     },
     "@financial-times/o-tracking": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-tracking/-/o-tracking-4.3.2.tgz",
-      "integrity": "sha512-lgrSbAyrQjpX6Zs2K+TtbGhCc2WcvxYR1y6zA2wsR+EY3Ohh8nxrQQQYjoprO0ZDskfS+GF4DtG2rwc2l+2llw==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-tracking/-/o-tracking-4.5.1.tgz",
+      "integrity": "sha512-CwUT4OyHIjR/cXFQR3EGyLiO6HCb26W7AAYgzr+40QUlutw9FJ4Y/RBKVW9+XBkcni4IWhdXKU5mD0Mm+wW7oA==",
       "requires": {
         "ftdomdelegate": "^5"
       }
@@ -11329,6 +11373,26 @@
       "integrity": "sha512-1c26V9B85waNQtGdn/Pokf+q+b0nyygVUTUyHoGj08xUKo7+xOBRunTdgVPJj2zdO5+ysBC77ka/sAu7r2y32A==",
       "requires": {
         "remove-accents": "^0.4.2"
+      }
+    },
+    "@financial-times/privacy-legislation-client": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/privacy-legislation-client/-/privacy-legislation-client-1.3.0.tgz",
+      "integrity": "sha512-S32eO94SosciyBzYehxoH7Tg45pO5Jz9KGwqUxVnAUrZuS4UzuKNmPVPKrRzQxbLbyaKbGtYbp9qf5RSf9SiXA=="
+    },
+    "@financial-times/privacy-us-privacy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/privacy-us-privacy/-/privacy-us-privacy-2.1.0.tgz",
+      "integrity": "sha512-l83sj1y9GfYZRrDAUk4P7HqBPffhL8oYrbEuSG+V7EFa4LTYKcy1/6ju1VGbzclbLhPeBUePB1bQ2G7BpvUPhQ==",
+      "requires": {
+        "@financial-times/privacy-legislation-client": "^2.1.0"
+      },
+      "dependencies": {
+        "@financial-times/privacy-legislation-client": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@financial-times/privacy-legislation-client/-/privacy-legislation-client-2.1.0.tgz",
+          "integrity": "sha512-NU7eh19nJ2CJJuF4qyTfbK82KXn5TBSS5uNiABaioYa7G8ey5mqfXT8oQid3GX9Dx4P7rhWqw3C3jFTsBf3Lig=="
+        }
       }
     },
     "@financial-times/sass-mq": {
@@ -11592,11 +11656,11 @@
       }
     },
     "@ft-interactive/vs-components": {
-      "version": "1.1.2",
-      "resolved": "https://npm.pkg.github.com/download/@ft-interactive/vs-components/1.1.2/7ea5819b795c118a044ac488a44ca28395ec8403",
-      "integrity": "sha512-UGaY4MIIfxEUYkxNXRFnTCC2ALw7E7gY5+9hhUrXOOyZXwZC8k2sXRIJ88xqV8t8DeR/aDxvOXsaIVcKThTXtg==",
+      "version": "1.2.1",
+      "resolved": "https://npm.pkg.github.com/download/@ft-interactive/vs-components/1.2.1/f3f3ea930113b466f2e60634f1c120f49f917246",
+      "integrity": "sha512-qyx2iUfnOwBqUViBePgd6fsBxqCd3Dzn9YYjeQRxfPtZfg25V6ndmolr1m3naKVnRPHtqqigS4LUCFZ+82VY7Q==",
       "requires": {
-        "@financial-times/g-components": "^9.0.1",
+        "@financial-times/g-components": "^9.0.3",
         "@financial-times/o-grid": "^6.1.7",
         "@financial-times/o-icons": "^7.7.0",
         "@financial-times/o-normalise": "^3.3.1",
@@ -17939,6 +18003,11 @@
       "requires": {
         "defaults": "^1.0.3"
       }
+    },
+    "web-vitals": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.5.0.tgz",
+      "integrity": "sha512-f5YnCHVG9Y6uLCePD4tY8bO/Ge15NPEQWtvm3tPzDKygloiqtb4SVqRHBcrIAqo2ztqX5XueqDn97zHF0LdT6w=="
     },
     "webidl-conversions": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@financial-times/g-components": "^9.0.1",
     "@financial-times/o-colors": "^6.6.0",
     "@financial-times/o-grid": "^6.1.5",
-    "@ft-interactive/vs-components": "^1.1.2",
+    "@ft-interactive/vs-components": "^1.2.0",
     "react": "^18.1.0",
     "react-dom": "^18.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@financial-times/g-components": "^9.0.1",
     "@financial-times/o-colors": "^6.6.0",
     "@financial-times/o-grid": "^6.1.5",
-    "@ft-interactive/vs-components": "^1.2.0",
+    "@ft-interactive/vs-components": "^1.2.1",
     "react": "^18.1.0",
     "react-dom": "^18.1.0"
   },


### PR DESCRIPTION
Bumps vs-components
Uses Credits component from vs-components (which contains Epilogue component which is why it's removed). Likely to be used in all projects so including by default. Empty credits (which we have here) will just render a horizontal rule followed by the share buttons and epilogue.