### PR TITLE
Set config.openCommentsAt

### DIFF
--- a/config/article.js
+++ b/config/article.js
@@ -189,5 +189,10 @@ export default (environment = 'development') => {
     config.linkPageUrl = `https://www.ft.com/content/${config.id}`;
   }
 
+  // Set the comments to open when the story publishes
+  if (!config.openCommentsAt) {
+    config.openCommentsAt = config.publishedDate;
+  }
+
   return config;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@financial-times/g-components": "^9.1.0",
+        "@financial-times/g-components": "^9.2.0",
         "@financial-times/o-colors": "^6.6.0",
         "@financial-times/o-grid": "^6.1.5",
         "@ft-interactive/vs-components": "^3.1.0",
@@ -856,9 +856,9 @@
       }
     },
     "node_modules/@financial-times/g-components": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/g-components/-/g-components-9.1.0.tgz",
-      "integrity": "sha512-3PlmaZDXi749NUv8MrIoBNiCs9Q52vQFnc8L5jVzP+40JUqr1mqvhwcQXJfA0zgIZ0e08tq0FEuI0wPMmcGNtg==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/g-components/-/g-components-9.2.0.tgz",
+      "integrity": "sha512-m7H+bjyf6/+fi7F/Y+b8+g/3J1j9LUBqMKoArFk2dn+qVcfN51RlxMKSq4dxdKiiINyjB4rw8N908iNPTcWP6Q==",
       "dependencies": {
         "@financial-times/ads-legacy-o-ads": "5.2.2",
         "@financial-times/flourish-receive-custom-analytics": "^1.2.0",
@@ -891,7 +891,7 @@
         "@financial-times/o-typography": "^7.3.2",
         "@financial-times/o-viewport": "^5.1.0",
         "@financial-times/o-visual-effects": "^4.2.0",
-        "@financial-times/politics": "^1.3.0",
+        "@financial-times/politics": "^3.0.0",
         "classnames": "^2.3.1",
         "d3-array": "^3.1.1",
         "d3-scale": "^4.0.2",
@@ -906,6 +906,19 @@
         "react": ">=17",
         "react-dom": ">=17"
       }
+    },
+    "node_modules/@financial-times/g-components/node_modules/@financial-times/politics": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/politics/-/politics-3.0.1.tgz",
+      "integrity": "sha512-7rs37jxJcPe9CnNyj/mgjNYq035DksqcVYgBzsx7Hv8SONEqeVc41rlARzVuyCav0jiNh/jrIoOf1Tax9kz6eg==",
+      "dependencies": {
+        "remove-accents": "^0.5.0"
+      }
+    },
+    "node_modules/@financial-times/g-components/node_modules/@financial-times/politics/node_modules/remove-accents": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
+      "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A=="
     },
     "node_modules/@financial-times/g-deploy": {
       "version": "3.2.0",
@@ -1501,6 +1514,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@financial-times/politics/-/politics-1.3.0.tgz",
       "integrity": "sha512-1c26V9B85waNQtGdn/Pokf+q+b0nyygVUTUyHoGj08xUKo7+xOBRunTdgVPJj2zdO5+ysBC77ka/sAu7r2y32A==",
+      "optional": true,
       "dependencies": {
         "remove-accents": "^0.4.2"
       }
@@ -11742,9 +11756,9 @@
       "integrity": "sha512-nVDEVgQTHU5vBQVC1zNb7erXDvOsugcPfTsm2L+nB0dSeIsGjKy+FMEUYpd05PQsw4c5H/IvownQuGLHhwolbw=="
     },
     "@financial-times/g-components": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/g-components/-/g-components-9.1.0.tgz",
-      "integrity": "sha512-3PlmaZDXi749NUv8MrIoBNiCs9Q52vQFnc8L5jVzP+40JUqr1mqvhwcQXJfA0zgIZ0e08tq0FEuI0wPMmcGNtg==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/g-components/-/g-components-9.2.0.tgz",
+      "integrity": "sha512-m7H+bjyf6/+fi7F/Y+b8+g/3J1j9LUBqMKoArFk2dn+qVcfN51RlxMKSq4dxdKiiINyjB4rw8N908iNPTcWP6Q==",
       "requires": {
         "@financial-times/ads-legacy-o-ads": "5.2.2",
         "@financial-times/flourish-receive-custom-analytics": "^1.2.0",
@@ -11777,7 +11791,7 @@
         "@financial-times/o-typography": "^7.3.2",
         "@financial-times/o-viewport": "^5.1.0",
         "@financial-times/o-visual-effects": "^4.2.0",
-        "@financial-times/politics": "^1.3.0",
+        "@financial-times/politics": "^3.0.0",
         "classnames": "^2.3.1",
         "d3-array": "^3.1.1",
         "d3-scale": "^4.0.2",
@@ -11787,6 +11801,23 @@
         "react-scroll-percentage": "^4.2.0",
         "remove-accents": "^0.4.2",
         "remove-markdown": "^0.3.0"
+      },
+      "dependencies": {
+        "@financial-times/politics": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@financial-times/politics/-/politics-3.0.1.tgz",
+          "integrity": "sha512-7rs37jxJcPe9CnNyj/mgjNYq035DksqcVYgBzsx7Hv8SONEqeVc41rlARzVuyCav0jiNh/jrIoOf1Tax9kz6eg==",
+          "requires": {
+            "remove-accents": "^0.5.0"
+          },
+          "dependencies": {
+            "remove-accents": {
+              "version": "0.5.0",
+              "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
+              "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A=="
+            }
+          }
+        }
       }
     },
     "@financial-times/g-deploy": {
@@ -12120,6 +12151,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@financial-times/politics/-/politics-1.3.0.tgz",
       "integrity": "sha512-1c26V9B85waNQtGdn/Pokf+q+b0nyygVUTUyHoGj08xUKo7+xOBRunTdgVPJj2zdO5+ysBC77ka/sAu7r2y32A==",
+      "optional": true,
       "requires": {
         "remove-accents": "^0.4.2"
       }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "@financial-times/g-components": "^9.1.0",
+    "@financial-times/g-components": "^9.2.0",
     "@financial-times/o-colors": "^6.6.0",
     "@financial-times/o-grid": "^6.1.5",
     "@ft-interactive/vs-components": "^3.1.0",


### PR DESCRIPTION
This PR updates the `config/article.js` template to set the `openCommentsAt` flag based on the `publishedDate` value. (If a developer wants to configure this date separately from the `publishedDate`, all they need to do is add an entry to the `config` element right below it.

This config is used by my new PR in `g-components` to avoid starting the 48-hour comment window until after the publication date: https://github.com/Financial-Times/g-components/pull/252
