### PR TITLE
Removes polyfill.io from page template

### DIFF
--- a/config/article.js
+++ b/config/article.js
@@ -126,8 +126,6 @@ export default (environment = 'development') => {
       // product: '',
     },
 
-    polyfillFeatures: ['default', 'fetch', 'es2019'],
-
     // If you include a data set, uncomment and fill out the following to
     // surface via Google.
     //

--- a/index.html
+++ b/index.html
@@ -13,7 +13,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     <link rel="preconnect" href="https://www.ft.com" />
-    <link rel="preconnect" href="https://polyfill-fastly.io" />
 
     <% (context.stylesheets || []).forEach(stylesheet=> { %>
     <link rel="stylesheet" href="<%= stylesheet %>" />
@@ -65,7 +64,6 @@
       <%= JSON.stringify({ sentryEndpoint: 'https://ddbd80489ff549538250bbe37fa52bbd@sentry.io/71130'}) %>
     </script>
     <% } %>
-    <script src="https://polyfill-fastly.io/v3/polyfill.min.js?features=<%= context.polyfillFeatures %>"></script>
 
     <script type="text/javascript">
       cutsTheMustard =


### PR DESCRIPTION
Polyfill.io was sold to a random Chinese company unaffiliated with the FT so we need to stop using it.

https://biz-ops.in.ft.com/Risk/polyfill-funnull