### PR TITLE
Set Node image tag 20.11-browsers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
     working_directory: ~/project
     executor:
       name: node/default
-      tag: '20.11.1-browsers'
+      tag: '20.11-browsers'
     steps:
       - run:
           name: Install git-lfs


### PR DESCRIPTION
Setting it to a specific version means that if any high priority CVEs are issued for the specific version of Node specified in the tag, we'll have to update everything again. This ensures that the minor version of Node we've specified will get bugfix updates until the end of the Node 20 LTE window.

## If you're arriving at this PR from Slack because you need to update this:

You want to update `.circleci/config.yaml` to be `tag: '20.11-browsers'`:

```diff
diff --git a/.circleci/config.yml b/.circleci/config.yml
index d5c893a..aa3c1d6 100644
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
     working_directory: ~/project
     executor:
       name: node/default
-      tag: '20.11.1-browsers'
+      tag: '20.11-browsers'
     steps:
       - run:
           name: Install git-lfs
```

https://github.com/ft-interactive/starter-kit/pull/332/files#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L19-R19