### PR TITLE
Add "You need to enable Javascript" message back in a noscript tag on…

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,6 +137,7 @@
     <meta property="fb:pages" content="293710391064899" />
   </head>
   <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"><%- appHtml %></div>
   </body>
 </html>


### PR DESCRIPTION
… the index.html template

I think this got accidentally omitted when we moved from webpack to vite so reinstating for users without javascript enabled.