### PR TITLE
Non archie fix

### DIFF
--- a/config/article.js
+++ b/config/article.js
@@ -44,13 +44,6 @@ export default (environment = 'development') => {
       url: 'https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fupload.wikimedia.org%2Fwikipedia%2Fcommons%2F3%2F3a%2F1905-03-ge-frankf-mapo.jpg?source=ig',
     },
 
-    // Byline can by a plain string, markdown, or array of authors
-    // if array of authors, url is optional
-    bylines: [
-      { name: 'Author One' /* , url: '/foo/bar' // Must be absolute path */ },
-      { name: 'Author Two' },
-    ],
-
     // Appears in the HTML <title>
     title: '',
 

--- a/config/data.js
+++ b/config/data.js
@@ -13,7 +13,7 @@
  * the latest version on the client.
  */
 
-import getArchieDoc from '../data/getArchieDoc.js';
+// import getArchieDoc from '../data/getArchieDoc.js';
 
 // eslint-disable-next-line no-unused-vars
 export async function fetchData(mode) {
@@ -33,8 +33,8 @@ export async function fetchData(mode) {
    */
 
   // We'll want to set story to null if not using an ArchieML doc
-  // const story = null;
-  const story = await getArchieDoc();
+  const story = null;
+  // const story = await getArchieDoc();
 
   // This { as: 'raw' } option imports files as plaintext
   const dataFiles = import.meta.glob('../data/*.csv', { as: 'raw' });


### PR DESCRIPTION
Fixing the default `data.js` method to not depend on having an ArchieML id