### PR TITLE
Test update for VSC

### DIFF
--- a/test/qa/qa.spec.cjs
+++ b/test/qa/qa.spec.cjs
@@ -85,7 +85,9 @@ describe('QA tests', () => {
     });
 
     it('has a populated topic link', () => {
-      const topicLink = document.querySelector('.o-editorial-typography-topic');
+      const topicLink = document.querySelector(
+        '.o-editorial-typography-topic, .vs-topper-text__topic'
+      );
 
       should.exist(topicLink);
       topicLink.textContent.should.not.equal('');
@@ -93,7 +95,9 @@ describe('QA tests', () => {
     });
 
     it('has a populated headline', () => {
-      const headline = document.querySelector('h1.o-editorial-layout-heading-1');
+      const headline = document.querySelector(
+        'h1.o-editorial-layout-heading-1, h1.vs-topper-text__headline'
+      );
 
       should.exist(headline);
       headline.textContent.should.not.equal('');


### PR DESCRIPTION
Updating QA tests slightly to work with VSC classes on headline and topic tag. Had some failing tests on build because the classes for the headline and topic tag are different than the tests expect with the new classes assigned in vs-components.