### PR TITLE
Fix text highlight ordering bug

### DIFF
--- a/app/util/text.jsx
+++ b/app/util/text.jsx
@@ -30,29 +30,33 @@ const findOverlappingHighlights = (matches) =>
 // Highlights is a list of { regex, className } pairs - each 'regex' must have a capture group
 // Returns JSX
 export function insertSpans(text, highlights, options = { p: true }) {
-  const matches = highlights.reduce((arr, highlight) => {
-    if (!(highlight.text || highlight.regex))
-      throw new Error('insertSpan(): Each span must have either highlight.text or highlight.regex');
+  const matches = highlights
+    .reduce((arr, highlight) => {
+      if (!(highlight.text || highlight.regex))
+        throw new Error(
+          'insertSpan(): Each span must have either highlight.text or highlight.regex'
+        );
 
-    const regexStr = highlight.regex || escapeRegex(highlight.text);
-    const regex = new RegExp(regexStr, 'igd');
+      const regexStr = highlight.regex || escapeRegex(highlight.text);
+      const regex = new RegExp(regexStr, 'igd');
 
-    let match;
-    // eslint-disable-next-line no-cond-assign
-    while ((match = regex.exec(text))) {
-      // Add all capture groups (but not the whole string) to the list
-      const { indices } = match;
-      arr.push(
-        ...match.slice(1).map((group, i) => ({
-          ...highlight,
-          match: group,
-          start: indices[i + 1][0],
-          end: indices[i + 1][1],
-        }))
-      );
-    }
-    return arr;
-  }, []);
+      let match;
+      // eslint-disable-next-line no-cond-assign
+      while ((match = regex.exec(text))) {
+        // Add all capture groups (but not the whole string) to the list
+        const { indices } = match;
+        arr.push(
+          ...match.slice(1).map((group, i) => ({
+            ...highlight,
+            match: group,
+            start: indices[i + 1][0],
+            end: indices[i + 1][1],
+          }))
+        );
+      }
+      return arr;
+    }, [])
+    .sort((a, b) => a.start - b.start);
 
   if (matches.length === 0) return options.p ? <p>{text}</p> : text;
 


### PR DESCRIPTION
Fixes a text highlight issue with the offset when highlights are not listed in order in config. This caused problems like this...

![Screenshot 2024-07-10 at 9 31 02 AM](https://github.com/ft-interactive/starter-kit/assets/12772904/b2a0a987-9982-4d2e-9249-ec0568b9dbec)

![Screenshot 2024-07-10 at 9 31 13 AM](https://github.com/ft-interactive/starter-kit/assets/12772904/933b79f6-4acc-4972-9e9a-639889789270)
866)

...because the reduce function was processing later highlights first, adding to the `offset` and then placing earlier highlights in the wrong spot, sometimes even inserting them mid-span tag. By just sorting on start index, this problem is avoided.