### PR TITLE
Add ignore glob pattern for preview files

### DIFF
--- a/assets/graphics/index.js
+++ b/assets/graphics/index.js
@@ -17,7 +17,7 @@ const DEFAULT_GRAPHIC_PROPS = {
   // alt: ''
 };
 
-const htmlFiles = import.meta.glob('./*/*.html', {
+const htmlFiles = import.meta.glob(['./*/*.html', '!*.preview.html'], {
   eager: true,
   query: '?raw',
   import: 'default',

--- a/assets/graphics/index.js
+++ b/assets/graphics/index.js
@@ -17,7 +17,7 @@ const DEFAULT_GRAPHIC_PROPS = {
   // alt: ''
 };
 
-const htmlFiles = import.meta.glob(['./*/*.html', '!*.preview.html'], {
+const htmlFiles = import.meta.glob(['./*/*.html', '!./*/*.preview.html'], {
   eager: true,
   query: '?raw',
   import: 'default',


### PR DESCRIPTION
I've recently made a tweak to the `ai2html` script to generate `.preview.html` files that you can use to see how the ai2html embed will look on a page. While this is a helpful feature, we do _not_ want to import these files into the projects — otherwise we're importing very long, unnecessary strings and adding about 1mb to the bundle size. 

To avoid this, I'm using the [Negative Patterns](https://vitejs.dev/guide/features#negative-patterns) feature of Vite's `import.meta.glob`, to import `.html` files but ignore `.preview.html` files in the `graphics/` glob expression.