### PR TITLE
Change url to use lower case version of CIRCLE_PROJECT_USERNAME so th…

### DIFF
--- a/config/url.js
+++ b/config/url.js
@@ -2,7 +2,7 @@
 export default function getUrl(
   articleUrl,
   environment = 'development',
-  org = process.env.CIRCLE_PROJECT_USERNAME,
+  org = process.env.CIRCLE_PROJECT_USERNAME?.toLowerCase(),
   project = process.env.CIRCLE_PROJECT_REPONAME,
   branch = process.env.CIRCLE_BRANCH
 ) {


### PR DESCRIPTION
…at preview builds work correctly - currently files are deployed to lowercase financial-times but are trying to load titlecase Financial-Times files and throwing 404s