### PR TITLE
Parse + format FT ellipses from ArchieML

### DIFF
--- a/components/BodyText/index.jsx
+++ b/components/BodyText/index.jsx
@@ -26,7 +26,7 @@ const BodyText = ({ elements, maxWidowSize = 8, extraMargin = true }) => (
         },
         {
           regex: /(…|\.\s?\.\s?\.)/,
-          className: 'ellipses',
+          className: 'nowrap',
           innerText: '. . .',
         },
       ]);

--- a/components/BodyText/index.jsx
+++ b/components/BodyText/index.jsx
@@ -27,7 +27,7 @@ const BodyText = ({ elements, maxWidowSize = 8, extraMargin = true }) => (
         {
           regex: /(…|\.\s?\.\s?\.)/,
           className: 'nowrap',
-          innerText: '. . .',
+          replace: '. . .',
         },
       ]);
 

--- a/components/BodyText/index.jsx
+++ b/components/BodyText/index.jsx
@@ -24,6 +24,11 @@ const BodyText = ({ elements, maxWidowSize = 8, extraMargin = true }) => (
           regex: new RegExp(`(\\w+\\s\\w{1,${maxWidowSize}}.?)$`),
           className: 'nowrap',
         },
+        {
+          regex: /(…|\.\s?\.\s?\.)/,
+          className: 'ellipses',
+          innerText: '. . .',
+        },
       ]);
 
       switch (type) {

--- a/components/BodyText/styles.scss
+++ b/components/BodyText/styles.scss
@@ -10,4 +10,8 @@
       margin: 72px auto;
     }
   }
+
+  .nowrap {
+    white-space: nowrap;
+  }
 }

--- a/components/BodyText/styles.scss
+++ b/components/BodyText/styles.scss
@@ -10,8 +10,4 @@
       margin: 72px auto;
     }
   }
-
-  .ellipses {
-    text-wrap: nowrap;
-  }
 }

--- a/components/BodyText/styles.scss
+++ b/components/BodyText/styles.scss
@@ -10,4 +10,8 @@
       margin: 72px auto;
     }
   }
+
+  .ellipses {
+    text-wrap: nowrap;
+  }
 }

--- a/util/getArchieDoc.js
+++ b/util/getArchieDoc.js
@@ -214,7 +214,13 @@ function parseBody(body, spans) {
       }
       obj[type] = value;
     }
-    if (obj.type) {
+
+    if (obj.type?.startsWith('scrolly')) {
+      components.push({
+        ...parseScrolly(obj[obj.type]),
+        ...obj,
+      });
+    } else if (obj.type) {
       components.push(obj);
     }
 

--- a/util/text.jsx
+++ b/util/text.jsx
@@ -78,9 +78,9 @@ export function insertSpans(text, highlights, options = { p: true }) {
       ];
 
       // Add a special "replace" tag if necessary
-      if (match.innerText)
+      if (match.replace)
         matchTags.push({
-          tag: match.innerText,
+          tag: match.replace,
           index: match.start,
           replace: match.end - match.start,
         });


### PR DESCRIPTION
As Sam pointed out last week, it's currently a pain to handle FT-style `. . .` ellipses in ArchieML, since Google Docs tries to format them into the unicode `…`. Additionally, even if you manually insert spaces to create an FT-style ellipsis, it could look broken on the front end if the text wraps the periods onto two lines.

This solves the issue using our `insertSpans` method, to match _either_ the unicode ellipsis or three period characters (with  or without spaces). It then (1) replaces the matched text with `. . .` (to guarantee the FT style ellipsis), and (2) adds a `nowrap` class to ensure it never gets split across two lines.

Additionally, I've added one tiny fix to the ArchieML parser - while testing with the [template doc](https://docs.google.com/document/d/1Oau3L_yCHpq1yv7MiNWTR1AdlgShLDE6r-36uXO1Vhc/edit?tab=t.0), I noticed that one of my previous commits had broken the in-body `scrolly` section parsing.
